### PR TITLE
New API for Handling Interactive Options in Prompt

### DIFF
--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -25,10 +25,11 @@ module CLI
         #
         # ==== Options
         #
-        # * +:options+ - Options to ask the user. Will use +InteractiveOptions+ to do so
         # * +:default+ - The default answer to the question (e.g. they just press enter and don't input anything)
         # * +:is_file+ - Tells the input to use file auto-completion (tab completion)
         # * +:allow_empty+ - Allows the answer to be empty
+        # * +:define_options+ - A Proc that takes a +OptionsHandler+ and uses the +:add_option+ method to
+        #                       add options and their respective handlers
         #
         # Note:
         # * +:options+ conflicts with +:default+ and +:is_file+, you cannot set options with either of these keywords
@@ -48,8 +49,12 @@ module CLI
         # Free form question when the answer can be empty
         #   CLI::UI::Prompt.ask('What is your opinion on this question?', allow_empty: true)
         #
-        # Question with answers
-        #   CLI::UI::Prompt.ask('What kind of project is this?', options: %w(rails go ruby python))
+        # Multiple choice question with defined handlers
+        #   CLI::UI::Prompt.ask('What kind of project is this?', options: %w(rails go ruby python)) do |handler|
+        #     handler.add_option('rails')  { |selection| puts selection } => outputs "rails" if selected
+        #     handler.add_option('go')     { |selection| puts selection } => outputs "go" if selected
+        #     handler.add_option('ruby')   { |selection| puts selection } => outputs "ruby" if selected
+        #     handler.add_option('python') { |selection| puts selection } => outputs "python" if selected
         #
         #
         def ask(question, default: nil, is_file: nil, allow_empty: true, &define_options)

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -5,17 +5,17 @@ module CLI
   module UI
     module Prompt
       autoload :InteractiveOptions,  'cli/ui/prompt/interactive_options'
-      private_constant :InteractiveOptions
+      autoload :OptionsHandler,      'cli/ui/prompt/options_handler'
+      private_constant :InteractiveOptions, :OptionsHandler
 
       class << self
         # Ask a user a question with either free form answer or a set of answers
+        # Do not use this method for multiple choice questions. Use +ask_interactive+
         # Do not use this method for yes/no questions. Use +confirm+
-        # Can use arrows, y/n, numbers, and vim bindings to control
         #
         # * Handles free form answers (options are nil)
         # * Handles default answers for free form text
         # * Handles file auto completion for file input
-        # * Handles interactively choosing answers using +InteractiveOptions+
         #
         # https://user-images.githubusercontent.com/3074765/33799822-47f23302-dd01-11e7-82f3-9072a5a5f611.png
         #
@@ -25,11 +25,10 @@ module CLI
         #
         # ==== Options
         #
+        # * +:options+ - Options that the user can select from. (DEPRECATED: use +ask_interactive+)
         # * +:default+ - The default answer to the question (e.g. they just press enter and don't input anything)
         # * +:is_file+ - Tells the input to use file auto-completion (tab completion)
         # * +:allow_empty+ - Allows the answer to be empty
-        # * +:define_options+ - A Proc that takes a +OptionsHandler+ and uses the +:add_option+ method to
-        #                       add options and their respective handlers
         #
         # Note:
         # * +:options+ conflicts with +:default+ and +:is_file+, you cannot set options with either of these keywords
@@ -49,39 +48,13 @@ module CLI
         # Free form question when the answer can be empty
         #   CLI::UI::Prompt.ask('What is your opinion on this question?', allow_empty: true)
         #
-        # Multiple choice question with defined handlers
-        #   CLI::UI::Prompt.ask('What kind of project is this?', options: %w(rails go ruby python)) do |handler|
-        #     handler.add_option('rails')  { |selection| puts selection } => outputs "rails" if selected
-        #     handler.add_option('go')     { |selection| puts selection } => outputs "go" if selected
-        #     handler.add_option('ruby')   { |selection| puts selection } => outputs "ruby" if selected
-        #     handler.add_option('python') { |selection| puts selection } => outputs "python" if selected
-        #
-        #
-        def ask(question, default: nil, is_file: nil, allow_empty: true, &define_options)
-          if (default && !allow_empty) || (block_given? && (default || is_file))
+        def ask(question, options: nil, default: nil, is_file: nil, allow_empty: true)
+          if (default && !allow_empty) || (options && (default || is_file))
             raise(ArgumentError, 'conflicting arguments')
           end
 
-          # Present the user with options
-          if block_given?
-            require 'cli/ui/prompt/options_handler'
-            handler = OptionsHandler.new
-
-            yield handler
-            raise(ArgumentError, 'insufficient options') if handler.options.size < 2
-
-            puts_question("#{question} {{yellow:(choose with ↑ ↓ ⏎)}}")
-            resp = InteractiveOptions.call(handler.options)
-
-            # Clear the line, and reset the question to include the answer
-            print(ANSI.previous_line + ANSI.end_of_line + ' ')
-            print(ANSI.cursor_save)
-            print(' ' * CLI::UI::Terminal.width)
-            print(ANSI.cursor_restore)
-            puts_question("#{question} (You chose: {{italic:#{resp}}})")
-
-            return handler.call(resp)
-          end
+          # For backwards compatibility
+          return ask_interactive(question, options) if options
 
           if default
             puts_question("#{question} (empty = #{default})")
@@ -104,6 +77,60 @@ module CLI
           end
         end
 
+        # Asks the user an interactive (multiple choice) question
+        # Can use arrows, y/n, numbers (1/2), and vim bindings to control
+        #
+        # * Handles interactively choosing answers using +InteractiveOptions+
+        #
+        # ==== Options
+        #
+        # * +:options+ - Options that the user can select from.
+        #
+        # ==== Block (optional)
+        #
+        # * A Proc that takes a +OptionsHandler+ and uses the public +:add_option+ method to add options and their
+        #   respective handlers
+        #
+        # Note:
+        # * +:options+ conflicts with passing in the +Block+
+        # * One of +:options+ or the +Block+ must be passed
+        #
+        # ==== Example Usage:
+        #
+        # Interactive (multiple choice) question
+        #   CLI::UI::Prompt.ask_interactive('What kind of project is this?', options: %w(rails go ruby python))
+        #
+        # Interactive (multiple choice) question with defined handlers
+        #   CLI::UI::Prompt.ask_interactive('What kind of project is this?', options: %w(rails go ruby python)) do |handler|
+        #     handler.add_option('rails')  { |selection| puts selection } => outputs "rails" if selected
+        #     handler.add_option('go')     { |selection| puts selection } => outputs "go" if selected
+        #     handler.add_option('ruby')   { |selection| puts selection } => outputs "ruby" if selected
+        #     handler.add_option('python') { |selection| puts selection } => outputs "python" if selected
+        #
+        def ask_interactive(question, options = nil)
+          raise(ArgumentError, 'conflicting arguments') if options && block_given?
+
+          options ||= if block_given?
+            handler = OptionsHandler.new
+            yield handler
+            handler.options
+          end
+
+          raise(ArgumentError, 'insufficient options') if options.nil? || options.size < 2
+          puts_question("#{question} {{yellow:(choose with ↑ ↓ ⏎)}}")
+          resp = InteractiveOptions.call(options)
+
+          # Clear the line, and reset the question to include the answer
+          print(ANSI.previous_line + ANSI.end_of_line + ' ')
+          print(ANSI.cursor_save)
+          print(' ' * CLI::UI::Terminal.width)
+          print(ANSI.cursor_restore)
+          puts_question("#{question} (You chose: {{italic:#{resp}}})")
+
+          return handler.call(resp) if block_given?
+          resp
+        end
+
         # Asks the user a yes/no question.
         # Can use arrows, y/n, numbers (1/2), and vim bindings to control
         #
@@ -113,10 +140,7 @@ module CLI
         #   CLI::UI::Prompt.confirm('Is the sky blue?')
         #
         def confirm(question)
-          ask(question) do |handler|
-            handler.add_option('yes') { |_| true }
-            handler.add_option('no') { |_| false }
-          end
+          ask_interactive(question, %w(yes no)) == 'yes'
         end
 
         private

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -41,6 +41,11 @@ module CLI
         # * A Proc that provides a +OptionsHandler+ and uses the public +:option+ method to add options and their
         #   respective handlers
         #
+        # ==== Return Value
+        #
+        # * If a +Block+ was not provided, the selected option or response to the free form question will be returned
+        # * If a +Block+ was provided, the evaluted value of the +Block+ will be returned
+        #
         # ==== Example Usage:
         #
         # Free form question
@@ -60,10 +65,10 @@ module CLI
         #
         # Interactive (multiple choice) question with defined handlers
         #   CLI::UI::Prompt.ask('What kind of project is this?') do |handler|
-        #     handler.option('rails')  { |selection| selection } => "rails" if selected
-        #     handler.option('go')     { |selection| selection } => "go" if selected
-        #     handler.option('ruby')   { |selection| selection } => "ruby" if selected
-        #     handler.option('python') { |selection| selection } => "python" if selected
+        #     handler.option('rails')  { |selection| selection }
+        #     handler.option('go')     { |selection| selection }
+        #     handler.option('ruby')   { |selection| selection }
+        #     handler.option('python') { |selection| selection }
         #   end
         #
         def ask(question, options: nil, default: nil, is_file: nil, allow_empty: true, &options_proc)

--- a/lib/cli/ui/prompt/options_handler.rb
+++ b/lib/cli/ui/prompt/options_handler.rb
@@ -1,0 +1,24 @@
+module CLI
+  module UI
+    module Prompt
+      # A class that handles the various options of an InteractivePrompt and their callbacks
+      class OptionsHandler
+        def initialize
+          @options = {}
+        end
+
+        def options
+          @options.keys
+        end
+
+        def add_option(option, &handler)
+          @options[option] = handler
+        end
+
+        def call(option)
+          @options[option].call(option)
+        end
+      end
+    end
+  end
+end

--- a/lib/cli/ui/prompt/options_handler.rb
+++ b/lib/cli/ui/prompt/options_handler.rb
@@ -11,7 +11,7 @@ module CLI
           @options.keys
         end
 
-        def add_option(option, &handler)
+        def option(option, &handler)
           @options[option] = handler
         end
 

--- a/test/cli/ui/prompt/options_handler_test.rb
+++ b/test/cli/ui/prompt/options_handler_test.rb
@@ -11,12 +11,12 @@ module CLI
           assert_empty handler.options
         end
 
-        def test_add_option
+        def test_option
           handler = OptionsHandler.new
 
-          handler.add_option('a') {}
-          handler.add_option('b') {}
-          handler.add_option('c') {}
+          handler.option('a') {}
+          handler.option('b') {}
+          handler.option('c') {}
 
           assert_equal ['a', 'b', 'c'], handler.options
         end
@@ -29,7 +29,7 @@ module CLI
             selection
           end
 
-          handler.add_option('a', &procedure)
+          handler.option('a', &procedure)
           assert_equal 'a', handler.call('a')
           assert procedure_called
         end

--- a/test/cli/ui/prompt/options_handler_test.rb
+++ b/test/cli/ui/prompt/options_handler_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+require 'cli/ui/prompt/options_handler'
+
+module CLI
+  module UI
+    module Prompt
+      class OptionsHandlerTest < MiniTest::Test
+        def test_initialize
+          handler = OptionsHandler.new
+
+          assert_empty handler.options
+        end
+
+        def test_add_option
+          handler = OptionsHandler.new
+
+          handler.add_option('a') {}
+          handler.add_option('b') {}
+          handler.add_option('c') {}
+
+          assert_equal ['a', 'b', 'c'], handler.options
+        end
+
+        def test_call
+          handler = OptionsHandler.new
+          procedure_called = false
+          procedure = Proc.new do |selection|
+            procedure_called = true
+            selection
+          end
+
+          handler.add_option('a', &procedure)
+          assert_equal 'a', handler.call('a')
+          assert procedure_called
+        end
+      end
+    end
+  end
+end

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -183,30 +183,29 @@ module CLI
         kwargsets = [
           { options: ['a'], default: 'a' },
           { options: ['a'], is_file: true },
-          { default: 'a', allow_empty: false },
         ]
 
         kwargsets.each do |kwargs|
           error = assert_raises(ArgumentError) { Prompt.ask('q', **kwargs) }
-          assert_equal 'conflicting arguments', error.message
+          assert_equal 'conflicting arguments: options provided with default or is_file', error.message
         end
 
         error = assert_raises(ArgumentError) do
-          Prompt.ask('q', is_file: true) {}
+          Prompt.ask('q', default: 'a', allow_empty: false)
         end
-        assert_equal 'conflicting arguments', error.message
+        assert_equal 'conflicting arguments: default enabled but allow_empty is false', error.message
 
         error = assert_raises(ArgumentError) do
           Prompt.ask('q', default: 'b') {}
         end
-        assert_equal 'conflicting arguments', error.message
+        assert_equal 'conflicting arguments: options provided with default or is_file', error.message
       end
 
       def test_ask_interactive_conflicting_arguments
         error = assert_raises(ArgumentError) do
           Prompt.ask('q', options: %w(a b)) { |h| h.option('a') }
         end
-        assert_equal 'conflicting arguments', error.message
+        assert_equal 'conflicting arguments: options and block given', error.message
       end
 
       def test_ask_interactive_insufficient_options


### PR DESCRIPTION
Issue: https://github.com/Shopify/cli-ui/issues/14

### What is accomplished in this PR
- changing the API for handling interactive options, so that they are defined within a block of the `ask` method
- removed the `options` key in the `ask` API
- added a new class to represent the various options and their attached handling procedures
- changed documentation and modified tests

New usage:
```ruby
CLI::UI::Prompt.ask("What is your choice?") do |handler|
    handler.add_option("Choice 1") { |c| puts "Choice 1" }
    handler.add_option("Choice 2") { |c| puts "Choice 2" }
end
```
 
cc @jules2689 @burke for review