### PR TITLE
Make readline work in non-tty

### DIFF
--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -177,7 +177,14 @@ module CLI
           # thread to manage output, but the current strategy feels like a
           # better tradeoff.
           prefix = CLI::UI.with_frame_color(:blue) { CLI::UI::Frame.prefix }
-          prompt = prefix + CLI::UI.fmt('{{blue:> }}{{yellow:')
+          suffix = CLI::UI.fmt('{{blue:> }}{{yellow:')
+          prompt = prefix + suffix
+
+          unless $stdin.tty?
+            ret = $stdin.readline.chomp
+            puts "#{suffix}#{ret}"
+            return ret
+          end
 
           begin
             line = Readline.readline(prompt, true)


### PR DESCRIPTION
Make readline work without a tty.  Necessary for testing.