### PR TITLE
Add Terminfo API for selecting ANSI escape codes

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -11,4 +11,5 @@ commands:
       else
         rake test $@
       fi
+  console: bin/console
   style: "bundle exec rubocop -D"

--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -34,11 +34,6 @@ module CLI
       def self.strip_codes(str)
         str.gsub(/\x1b\[[\d;]+[A-z]|\r/, '')
       end
-
-      # https://en.wikipedia.org/wiki/ANSI_escape_code#graphics
-      def self.sgr(params)
-        "\x1b[#{params}m"
-      end
     end
   end
 end

--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -3,8 +3,6 @@ require 'cli/ui'
 module CLI
   module UI
     module ANSI
-      ESC = "\x1b"
-
       # ANSI escape sequences (like \x1b[31m) have zero width.
       # when calculating the padding width, we must exclude them.
       # This also implements a basic version of utf8 character width calculation like
@@ -37,118 +35,9 @@ module CLI
         str.gsub(/\x1b\[[\d;]+[A-z]|\r/, '')
       end
 
-      # Returns an ANSI control sequence
-      #
-      # ==== Attributes
-      #
-      # - +args+ - Argument to pass to the ANSI control sequence
-      # - +cmd+ - ANSI control sequence Command
-      #
-      def self.control(args, cmd)
-        ESC + "[" + args + cmd
-      end
-
       # https://en.wikipedia.org/wiki/ANSI_escape_code#graphics
       def self.sgr(params)
-        control(params.to_s, 'm')
-      end
-
-      # Cursor Movement
-
-      # Move the cursor up n lines
-      #
-      # ==== Attributes
-      #
-      # * +n+ - number of lines by which to move the cursor up
-      #
-      def self.cursor_up(n = 1)
-        return '' if n.zero?
-        control(n.to_s, 'A')
-      end
-
-      # Move the cursor down n lines
-      #
-      # ==== Attributes
-      #
-      # * +n+ - number of lines by which to move the cursor down
-      #
-      def self.cursor_down(n = 1)
-        return '' if n.zero?
-        control(n.to_s, 'B')
-      end
-
-      # Move the cursor forward n columns
-      #
-      # ==== Attributes
-      #
-      # * +n+ - number of columns by which to move the cursor forward
-      #
-      def self.cursor_forward(n = 1)
-        return '' if n.zero?
-        control(n.to_s, 'C')
-      end
-
-      # Move the cursor back n columns
-      #
-      # ==== Attributes
-      #
-      # * +n+ - number of columns by which to move the cursor back
-      #
-      def self.cursor_back(n = 1)
-        return '' if n.zero?
-        control(n.to_s, 'D')
-      end
-
-      # Move the cursor to a specific column
-      #
-      # ==== Attributes
-      #
-      # * +n+ - The column to move to
-      #
-      def self.cursor_horizontal_absolute(n = 1)
-        control(n.to_s, 'G')
-      end
-
-      # Show the cursor
-      #
-      def self.show_cursor
-        control('', "?25h")
-      end
-
-      # Hide the cursor
-      #
-      def self.hide_cursor
-        control('', "?25l")
-      end
-
-      # Save the cursor position
-      #
-      def self.cursor_save
-        control('', 's')
-      end
-
-      # Restore the saved cursor position
-      #
-      def self.cursor_restore
-        control('', 'u')
-      end
-
-      # Move to the next line
-      #
-      def self.next_line
-        cursor_down + control('1', 'G')
-      end
-
-      # Move to the previous line
-      #
-      def self.previous_line
-        cursor_up + control('1', 'G')
-      end
-
-      # Move to the end of the line
-      #
-      def self.end_of_line
-        control("\033[", 'C')
+        "\x1b[#{params}m"
       end
     end
   end

--- a/lib/cli/ui/color.rb
+++ b/lib/cli/ui/color.rb
@@ -3,43 +3,52 @@ require 'cli/ui'
 module CLI
   module UI
     class Color
-      attr_reader :sgr, :name, :code
+      attr_reader :index, :name, :to_s
 
       # Creates a new color mapping
-      # Signatures can be found here:
-      # https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+      #
+      # The +index+ parameter can be 0 through 7, or 8
+      # through 15 for bright colours, or whatever other
+      # arguments +setaf+ can take.
+      #
+      # https://www.freebsd.org/cgi/man.cgi?query=terminfo&sektion=5
       #
       # ==== Attributes
       #
-      # * +sgr+ - The color signature
+      # * +index+ - The color argument for terminfo
       # * +name+ - The name of the color
       #
-      def initialize(sgr, name)
-        @sgr  = sgr
-        @code = CLI::UI::ANSI.sgr(sgr)
+      def initialize(index, name)
+        @index = index
+        @to_s = CLI::UI::Terminal.fg_color(index)
         @name = name
       end
 
-      RED     = new('31', :red)
-      GREEN   = new('32', :green)
-      YELLOW  = new('33', :yellow)
-      # default blue is low-contrast against black in some default terminal color scheme
-      BLUE    = new('94', :blue) # 9x = high-intensity fg color x
-      MAGENTA = new('35', :magenta)
-      CYAN    = new('36', :cyan)
-      RESET   = new('0',  :reset)
-      BOLD    = new('1',  :bold)
-      WHITE   = new('97', :white)
+      # default blue is low-contrast against black in some
+      #   default terminal color scheme
+      #
+      # when we want white, it looks better bright, too.
+      bright = 8
+
+      BLACK    = new(0,          :black)
+      RED      = new(1,          :red)
+      GREEN    = new(2,          :green)
+      YELLOW   = new(3,          :yellow)
+      BLUE     = new(4 + bright, :blue)
+      DIM_BLUE = new(4,          :dim_blue)
+      MAGENTA  = new(5,          :magenta)
+      CYAN     = new(6,          :cyan)
+      WHITE    = new(7 + bright, :white)
 
       MAP = {
+        black:   BLACK,
         red:     RED,
         green:   GREEN,
         yellow:  YELLOW,
         blue:    BLUE,
         magenta: MAGENTA,
         cyan:    CYAN,
-        reset:   RESET,
-        bold:    BOLD,
+        white:   WHITE,
       }.freeze
 
       class InvalidColorName < ArgumentError

--- a/lib/cli/ui/formatter.rb
+++ b/lib/cli/ui/formatter.rb
@@ -13,23 +13,23 @@ module CLI
       #
       SGR_MAP = {
         # presentational
-        'red'       => '31',
-        'green'     => '32',
-        'yellow'    => '33',
-        'blue'      => '34',
-        'magenta'   => '35',
-        'cyan'      => '36',
-        'bold'      => '1',
-        'italic'    => '3',
-        'underline' => '4',
-        'reset'     => '0',
+        'red'       => CLI::UI::Color::RED.to_s,
+        'green'     => CLI::UI::Color::GREEN.to_s,
+        'yellow'    => CLI::UI::Color::YELLOW.to_s,
+        'blue'      => CLI::UI::Color::DIM_BLUE.to_s,
+        'magenta'   => CLI::UI::Color::MAGENTA.to_s,
+        'cyan'      => CLI::UI::Color::CYAN.to_s,
+        'bold'      => CLI::UI::Terminal.bold_on,
+        'italic'    => CLI::UI::Terminal.italics_on,
+        'underline' => CLI::UI::Terminal.underline_on,
+        'reset'     => CLI::UI::Terminal.sgr0,
 
         # semantic
-        'error'   => '31', # red
-        'success' => '32', # success
-        'warning' => '33', # yellow
-        'info'    => '34', # blue
-        'command' => '36', # cyan
+        'error'   => CLI::UI::Color::RED.to_s,
+        'success' => CLI::UI::Color::GREEN.to_s,
+        'warning' => CLI::UI::Color::YELLOW.to_s,
+        'info'    => CLI::UI::Color::DIM_BLUE.to_s,
+        'command' => CLI::UI::Color::CYAN.to_s,
       }.freeze
 
       BEGIN_EXPR = '{{'
@@ -105,11 +105,14 @@ module CLI
 
       private
 
+      # IDEA:
+      # track only fg color and sgr modes
+      # do sgr, then setaf
       def apply_format(text, fmt, sgr_map)
-        sgr = fmt.each_with_object(String.new('0')) do |name, str|
+        formatter = fmt.each_with_object(String.new('')) do |name, str|
           next if name == LITERAL_BRACES
           begin
-            str << ';' << sgr_map.fetch(name)
+            str << sgr_map.fetch(name)
           rescue KeyError
             raise FormatError.new(
               "invalid format specifier: #{name}",
@@ -118,7 +121,7 @@ module CLI
             )
           end
         end
-        CLI::UI::ANSI.sgr(sgr) + text
+        formatter + text
       end
 
       def parse_expr(sc, stack)

--- a/lib/cli/ui/frame.rb
+++ b/lib/cli/ui/frame.rb
@@ -252,12 +252,12 @@ module CLI
           is_ci = ![0, '', nil].include?(ENV['CI'])
 
           # Jumping around the line can cause some unwanted flashes
-          o << CLI::UI::ANSI.hide_cursor
+          o << CLI::UI::Terminal.hide_cursor
 
           o << if is_ci
                  # In CI, we can't use absolute horizontal positions because of timestamps.
                  # So we move around the line by offset from this cursor position.
-                 CLI::UI::ANSI.cursor_save
+                 CLI::UI::Terminal.save_cursor
                else
                  # Outside of CI, we reset to column 1 so that things like ^C don't
                  # cause output misformatting.
@@ -270,7 +270,7 @@ module CLI
           o << color.code
           o << print_at_x(suffix_start, suffix, is_ci)
           o << CLI::UI::Color::RESET.code
-          o << CLI::UI::ANSI.show_cursor
+          o << CLI::UI::Terminal.show_cursor
           o << "\n"
 
           o
@@ -278,9 +278,9 @@ module CLI
 
         def print_at_x(x, str, is_ci)
           if is_ci
-            CLI::UI::ANSI.cursor_restore + CLI::UI::ANSI.cursor_forward(x) + str
+            CLI::UI::Terminal.restore_cursor + CLI::UI::Terminal.cursor_right(x) + str
           else
-            CLI::UI::ANSI.cursor_horizontal_absolute(1 + x) + str
+            CLI::UI::Terminal.cursor_horizontal_absolute(1 + x) + str
           end
         end
 

--- a/lib/cli/ui/progress.rb
+++ b/lib/cli/ui/progress.rb
@@ -30,13 +30,13 @@ module CLI
       #   end
       def self.progress(width: Terminal.width)
         bar = Progress.new(width: width)
-        print CLI::UI::ANSI.hide_cursor
+        print CLI::UI::Terminal.hide_cursor
         yield(bar)
       ensure
         puts bar.to_s
         CLI::UI.raw do
-          print(ANSI.show_cursor)
-          puts(ANSI.previous_line + ANSI.end_of_line)
+          print(Terminal.show_cursor)
+          puts(Terminal.previous_line + Terminal.clear_to_end_of_line)
         end
       end
 
@@ -67,8 +67,8 @@ module CLI
         @percent_done = [@percent_done, 1.0].min # Make sure we can't go above 1.0
 
         print to_s
-        print CLI::UI::ANSI.previous_line
-        print CLI::UI::ANSI.end_of_line + "\n"
+        print CLI::UI::Terminal.previous_line
+        print CLI::UI::Terminal.clear_to_end_of_line + "\n"
       end
 
       # Format the progress bar to be printed to terminal

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -135,10 +135,10 @@ module CLI
           resp = InteractiveOptions.call(options)
 
           # Clear the line, and reset the question to include the answer
-          print(ANSI.previous_line + ANSI.end_of_line + ' ')
-          print(ANSI.cursor_save)
-          print(' ' * CLI::UI::Terminal.width)
-          print(ANSI.cursor_restore)
+          print(Terminal.previous_line + Terminal.clear_to_end_of_line + ' ')
+          print(Terminal.save_cursor)
+          print(' ' * Terminal.width)
+          print(Terminal.restore_cursor)
           puts_question("#{question} (You chose: {{italic:#{resp}}})")
 
           return handler.call(resp) if block_given?
@@ -148,9 +148,9 @@ module CLI
         def write_default_over_empty_input(default)
           CLI::UI.raw do
             STDERR.puts(
-              CLI::UI::ANSI.cursor_up(1) +
+              CLI::UI::Terminal.cursor_up(1) +
               "\r" +
-              CLI::UI::ANSI.cursor_forward(4) + # TODO: width
+              CLI::UI::Terminal.cursor_right(4) + # TODO: width
               default +
               CLI::UI::Color::RESET.code
             )

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -39,7 +39,7 @@ module CLI
         # Usually used from +self.call+
         #
         def call
-          CLI::UI.raw { print(ANSI.hide_cursor) }
+          CLI::UI.raw { print(Terminal.hide_cursor) }
           while @answer.nil?
             render_options
             wait_for_user_input
@@ -49,8 +49,8 @@ module CLI
           @answer
         ensure
           CLI::UI.raw do
-            print(ANSI.show_cursor)
-            puts(ANSI.previous_line + ANSI.end_of_line)
+            print(Terminal.show_cursor)
+            puts(Terminal.previous_line + Terminal.clear_to_end_of_line)
           end
         end
 
@@ -60,8 +60,8 @@ module CLI
           # This will put us back at the beginning of the options
           # When we redraw the options, they will be overwritten
           CLI::UI.raw do
-            num_lines.times { print(ANSI.previous_line) }
-            print(ANSI.previous_line + ANSI.end_of_line + "\n")
+            num_lines.times { print(Terminal.previous_line) }
+            print(Terminal.previous_line + Terminal.clear_to_end_of_line + "\n")
           end
         end
 

--- a/lib/cli/ui/spinner/spin_group.rb
+++ b/lib/cli/ui/spinner/spin_group.rb
@@ -107,7 +107,7 @@ module CLI
           end
 
           def partial_render(index)
-            CLI::UI::ANSI.cursor_forward(inset_width) + glyph(index) + CLI::UI::Color::RESET.code
+            CLI::UI::Terminal.cursor_right(inset_width) + glyph(index) + CLI::UI::Color::RESET.code
           end
 
           def glyph(index)
@@ -170,8 +170,8 @@ module CLI
                     @consumed_lines += 1
                   else
                     offset = @consumed_lines - int_index
-                    move_to   = CLI::UI::ANSI.cursor_up(offset) + "\r"
-                    move_from = "\r" + CLI::UI::ANSI.cursor_down(offset)
+                    move_to   = CLI::UI::Terminal.cursor_up(offset) + "\r"
+                    move_from = "\r" + CLI::UI::Terminal.cursor_down(offset)
 
                     print(move_to + task.render(idx, idx.zero?) + move_from)
                   end

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -1,21 +1,199 @@
 require 'cli/ui'
-require 'io/console'
+require 'fiddle'
 
 module CLI
   module UI
     module Terminal
-      # Returns the width of the terminal, if possible
-      # Otherwise will return 80
+      # Useful references:
       #
+      # List of capability names:
+      #   https://www.freebsd.org/cgi/man.cgi?query=terminfo&sektion=5
+      # Xterm terminfo settings:
+      #   https://invisible-island.net/xterm/terminfo.html
+
       def self.width
-        if console = IO.respond_to?(:console) && IO.console
-          console.winsize[1]
-        else
-          80
-        end
-      rescue Errno::EIO
-        80
+        TermInfo.tigetnum('cols') || 80
       end
+
+      def self.height
+        TermInfo.tigetnum('lines') || 24
+      end
+
+      def self.cursor_right(n = 1)
+        n == 1 ? fmt('cuf1') : fmt('cuf', n)
+      end
+
+      def self.cursor_left(n = 1)
+        n == 1 ? fmt('cub1') : fmt('cub', n)
+      end
+
+      def self.cursor_up(n = 1)
+        n == 1 ? fmt('cuu1') : fmt('cuu', n)
+      end
+
+      def self.cursor_down(n = 1)
+        n == 1 ? fmt('cud1') : fmt('cud', n)
+      end
+
+      def self.horizontal_position_absolute(n)
+        fmt('hpa', n)
+      end
+
+      def self.vertical_position_absolute(n)
+        fmt('vpa', n)
+      end
+
+      def self.clear_to_end_of_line
+        fmt('el')
+      end
+
+      def self.cursor_normal
+        fmt('cnorm')
+      end
+
+      def self.cursor_very_visible
+        fmt('cvvis')
+      end
+
+      def self.cursor_invisible
+        fmt('civis')
+      end
+
+      def self.set_foreground(n)
+        fmt('setaf', n)
+      end
+
+      def self.set_background(n)
+        fmt('setab', n)
+      end
+
+      def self.italics_on
+        fmt('sitm')
+      end
+
+      def self.italics_off
+        fmt('ritm')
+      end
+
+      def self.underline_on
+        fmt('smul')
+      end
+
+      def self.underline_off
+        fmt('rmul')
+      end
+
+      def self.bold_on
+        fmt('bold')
+      end
+
+      def self.exit_attribute_mode
+        fmt('sgr0')
+      end
+
+      def self.save_cursor
+        fmt('sc')
+      end
+
+      def self.restore_cursor
+        fmt('rc')
+      end
+
+      def self.fmt(capname, *args)
+        cap = TermInfo.tigetstr(capname)
+        return "" unless cap
+        return cap if args.empty?
+        TermInfo.tparm(cap, *args)
+      end
+      private_class_method :fmt
+
+      module TermInfo
+        TERM = 'TERM'.freeze
+        DEFAULT_TERM = 'xterm'.freeze
+        STDOUT_FD = STDOUT.to_i
+
+        class << self
+          def tigetstr(str, term: termvar)
+            setupterm_once(term)
+            ret = TIGETSTR.call(str)
+            ret.to_i == -1 ? nil : ret.to_s
+          end
+
+          def tigetnum(str, term: termvar)
+            setupterm_once(term)
+            ret = TIGETNUM.call(str)
+            ret.to_i == -1 ? nil : ret
+          end
+
+          def tparm(str, *args)
+            # setupterm_once(term) probably not necessary
+            ret = TPARM[args.size].call(str, *args)
+            ret.null? ? "" : ret.to_s
+          end
+
+          private
+
+          def setupterm_once(term)
+            return if @active == term
+            SETUPTERM.call(term, STDOUT_FD, 0)
+            @active = term
+          end
+
+          def termvar
+            ENV.fetch(TERM, DEFAULT_TERM)
+          end
+        end
+
+        private
+
+        # TODO: manage libncurses dependency on Linux
+        LIBTERMCAP = Fiddle.dlopen('/usr/lib/libtermcap.dylib')
+        private_constant :LIBTERMCAP
+
+        TIGETFLAG = Fiddle::Function.new(
+          LIBTERMCAP['tigetflag'],
+          [Fiddle::TYPE_VOIDP],
+          Fiddle::TYPE_INT
+        )
+
+        TIGETNUM = Fiddle::Function.new(
+          LIBTERMCAP['tigetnum'],
+          [Fiddle::TYPE_VOIDP],
+          Fiddle::TYPE_INT
+        )
+
+        TPARM = (0..2).map do |n|
+          Fiddle::Function.new(
+            LIBTERMCAP['tparm'],
+            [Fiddle::TYPE_VOIDP] * (n + 1),
+            Fiddle::TYPE_VOIDP
+          )
+        end
+
+        # TPUTS = Fiddle::Function.new(
+        #   LIBTERMCAP['tputs'],
+        # )
+
+        SETUPTERM = Fiddle::Function.new(
+          LIBTERMCAP['setupterm'],
+          [
+            Fiddle::TYPE_VOIDP,    # char *term
+            Fiddle::TYPE_INT,      # int fildes
+            Fiddle::TYPE_INTPTR_T, # int *errret
+          ],
+          Fiddle::TYPE_INT
+        )
+        private_constant :SETUPTERM
+
+        TIGETSTR = Fiddle::Function.new(
+          LIBTERMCAP['tigetstr'],
+          [Fiddle::TYPE_VOIDP],
+          Fiddle::TYPE_VOIDP
+        )
+        private_constant :TIGETSTR
+      end
+
+      private_constant :TermInfo
     end
   end
 end

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -19,27 +19,39 @@ module CLI
         TermInfo.tigetnum('lines') || 24
       end
 
+      def self.previous_line
+        cursor_up + cursor_horizontal_absolute(1)
+      end
+
+      def self.next_line
+        cursor_down + cursor_horizontal_absolute(1)
+      end
+
       def self.cursor_right(n = 1)
+        return '' if n.zero?
         n == 1 ? fmt('cuf1') : fmt('cuf', n)
       end
 
       def self.cursor_left(n = 1)
+        return '' if n.zero?
         n == 1 ? fmt('cub1') : fmt('cub', n)
       end
 
       def self.cursor_up(n = 1)
+        return '' if n.zero?
         n == 1 ? fmt('cuu1') : fmt('cuu', n)
       end
 
       def self.cursor_down(n = 1)
+        return '' if n.zero?
         n == 1 ? fmt('cud1') : fmt('cud', n)
       end
 
-      def self.horizontal_position_absolute(n)
+      def self.cursor_horizontal_absolute(n)
         fmt('hpa', n)
       end
 
-      def self.vertical_position_absolute(n)
+      def self.cursor_vertical_absolute(n)
         fmt('vpa', n)
       end
 
@@ -47,23 +59,19 @@ module CLI
         fmt('el')
       end
 
-      def self.cursor_normal
+      def self.show_cursor
         fmt('cnorm')
       end
 
-      def self.cursor_very_visible
-        fmt('cvvis')
-      end
-
-      def self.cursor_invisible
+      def self.hide_cursor
         fmt('civis')
       end
 
-      def self.set_foreground(n)
+      def self.fg_color(n)
         fmt('setaf', n)
       end
 
-      def self.set_background(n)
+      def self.bg_color(n)
         fmt('setab', n)
       end
 
@@ -144,8 +152,6 @@ module CLI
           end
         end
 
-        private
-
         # TODO: manage libncurses dependency on Linux
         LIBTERMCAP = Fiddle.dlopen('/usr/lib/libtermcap.dylib')
         private_constant :LIBTERMCAP
@@ -162,7 +168,7 @@ module CLI
           Fiddle::TYPE_INT
         )
 
-        TPARM = (0..2).map do |n|
+        TPARM = (0..10).map do |n|
           Fiddle::Function.new(
             LIBTERMCAP['tparm'],
             [Fiddle::TYPE_VOIDP] * (n + 1),


### PR DESCRIPTION
Part 1.

From here, I'll kill most of `CLI::UI::ANSI` (leaving e.g. `strip_codes`) and refactor `Formatter` and other uses to this API.

This allows us to suppress colour with e.g. `TERM=dumb`.