### PR TITLE
Fix example prompt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ CLI::UI.ask('What language/framework do you use?', options: %w(rails go ruby pyt
 Can also assign callbacks to each option
 
 ```ruby
-CLI::UI.ask('What language/framework do you use?') do |handler|
+CLI::UI::Prompt.ask('What language/framework do you use?') do |handler|
   handler.option('rails')  { |selection| selection }
   handler.option('go')     { |selection| selection }
   handler.option('ruby')   { |selection| selection }


### PR DESCRIPTION
The call to `CLI::UI.ask` does not correctly display the prompt options as shown in the example. It'll display the question but not the options. This small correction to the readme shows the proper call that results in the options being shown . 