### PR TITLE
Patch blank option name edge case

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -76,8 +76,13 @@ module CLI
         def num_lines
           # @options will be an array of questions but each option can be multi-line
           # so to get the # of lines, you need to join then split
+
+          # empty_option_count is needed since empty option titles are omitted
+          # from the line count when reject(&:empty?) is called
+
+          empty_option_count =  @options.count(&:empty?)
           joined_options = @options.join("\n")
-          joined_options.split("\n").reject(&:empty?).size
+          joined_options.split("\n").reject(&:empty?).size + empty_option_count
         end
 
         ESC = "\e"

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -349,6 +349,34 @@ module CLI
         assert_result(expected_out, "", "b")
       end
 
+      def test_ask_interactive_with_blank_option
+        _run('j','j',' ') do
+          Prompt.ask('q') do |h|
+            h.option('a') { |a| 'a was selected' }
+            h.option('') { |b| 'b was selected' }
+          end
+        end
+        blank = ''
+        expected_out = strip_heredoc(<<-EOF)
+          ? q (choose with ↑ ↓ ⏎)
+          \e[?25l> 1. a
+            2.#{blank}
+          \e[\e[C
+            1. a
+          > 2.#{blank}
+          \e[\e[C
+          > 1. a
+            2.#{blank}
+          \e[\e[C
+          #{' ' * CLI::UI::Terminal.width}
+          #{' ' * CLI::UI::Terminal.width}
+          \e[\e[C
+          \e[?25h\e[\e[C
+          \e[\e[C \e[s#{' ' * CLI::UI::Terminal.width}\e[u? q (You chose: a)
+        EOF
+        assert_result(expected_out, "", "a was selected")
+      end
+
       private
 
       def _run(*lines)


### PR DESCRIPTION
Prior to this PR, if you were to create an option handler with a blank title (a title denoted by ""). CLI-UI would have issues when it came to scrolling. This is caused because when cli-kit updates the screen in response to user input (ex: scrolling), it needs to count how many lines to clear and update. When a blank option is given, this line is not accounted for and results in the error. The PR counts these blank lines that aren't accounted for and adds them back into the total line count.

# Before
![pre-fix bug](https://user-images.githubusercontent.com/15018469/38449582-aa2e927e-39de-11e8-9131-64bc8c68921f.gif)

# After
![post bug fix](https://user-images.githubusercontent.com/15018469/38449585-b9075df8-39de-11e8-83c8-44a099d0abc1.gif)
