### PR TITLE
Fix StdoutRouter for ruby 2.5

### DIFF
--- a/lib/cli/ui/stdout_router.rb
+++ b/lib/cli/ui/stdout_router.rb
@@ -15,13 +15,15 @@ module CLI
         end
 
         def write(*args)
-          if auto_frame_inset?
-            str = args[0].dup # unfreeze
-            str = str.force_encoding(Encoding::UTF_8)
-            str = apply_line_prefix(str, CLI::UI::Frame.prefix)
-            args[0] = str
-          else
-            @pending_newline = false
+          args = args.map do |str|
+            if auto_frame_inset?
+              str = str.dup # unfreeze
+              str = str.force_encoding(Encoding::UTF_8)
+              apply_line_prefix(str, CLI::UI::Frame.prefix)
+            else
+              @pending_newline = false
+              str
+            end
           end
 
           hook = Thread.current[:cliui_output_hook]

--- a/lib/cli/ui/version.rb
+++ b/lib/cli/ui/version.rb
@@ -1,5 +1,5 @@
 module CLI
   module UI
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end


### PR DESCRIPTION
Ruby 2.5 changed `IO#write` from `write(string)` to `write(string, ...)`.  Before 2.5, `puts "Hello"` would call `write("Hello"); write("\n")`.  It now calls `write("Hello", "\n")`.