### PR TITLE
Add chevron glyph, to be used for debug output

### DIFF
--- a/lib/cli/ui/glyph.rb
+++ b/lib/cli/ui/glyph.rb
@@ -50,6 +50,8 @@ module CLI
       X        = new('x', 0x2717,  Color::RED)
       # Bug emoji (🐛)
       BUG      = new('b', 0x1f41b, Color::WHITE)
+      # RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK (»)
+      CHEVRON  = new('>', 0xbb,    Color::YELLOW)
 
       # Looks up a glyph by name
       #

--- a/test/cli/ui/glyph_test.rb
+++ b/test/cli/ui/glyph_test.rb
@@ -10,6 +10,7 @@ module CLI
         assert_equal("\x1b[32m✓\x1b[0m", Glyph::CHECK.to_s)
         assert_equal("\x1b[31m✗\x1b[0m", Glyph::X.to_s)
         assert_equal("\x1b[97m🐛\x1b[0m", Glyph::BUG.to_s)
+        assert_equal("\x1b[33m»\x1b[0m", Glyph::CHEVRON.to_s)
 
         assert_equal(Glyph::STAR,     Glyph.lookup('*'))
         assert_equal(Glyph::INFO,     Glyph.lookup('i'))
@@ -17,6 +18,7 @@ module CLI
         assert_equal(Glyph::CHECK,    Glyph.lookup('v'))
         assert_equal(Glyph::X,        Glyph.lookup('x'))
         assert_equal(Glyph::BUG,      Glyph.lookup('b'))
+        assert_equal(Glyph::CHEVRON,  Glyph.lookup('>'))
 
         assert_raises(Glyph::InvalidGlyphHandle) do
           Glyph.lookup('$')


### PR DESCRIPTION
Added a test and tested with a puts that it prints to my terminal (iTerm2 + tmux + zsh)

![image](https://user-images.githubusercontent.com/1216046/40134491-899d73bc-5910-11e8-8441-7796b3707fb4.png)
