### PR TITLE
Fix interactive prompt for options > terminal rows

### DIFF
--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -150,6 +150,10 @@ module CLI
       def self.end_of_line
         control("\033[", 'C')
       end
+
+      def self.clear_to_end_of_line
+        control('', 'K')
+      end
     end
   end
 end

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -5,6 +5,7 @@ module CLI
   module UI
     module Terminal
       DEFAULT_WIDTH = 80
+      DEFAULT_HEIGHT = 24
 
       # Returns the width of the terminal, if possible
       # Otherwise will return 80
@@ -18,6 +19,17 @@ module CLI
         end
       rescue Errno::EIO
         DEFAULT_WIDTH
+      end
+
+      def self.height
+        if console = IO.respond_to?(:console) && IO.console
+          height = console.winsize[0]
+          height.zero? ? DEFAULT_HEIGHT : height
+        else
+          DEFAULT_HEIGHT
+        end
+      rescue Errno::EIO
+        DEFAULT_HEIGHT
       end
     end
   end

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -37,11 +37,8 @@ module CLI
 
         expected_out = strip_heredoc(<<-EOF) + ' '
           ? q (choose with ↑ ↓ ⏎)
-          \e[?25l> 1. yes
-            2. no
-          \e[\e[C
-          > 1. yes
-            2. no
+          \e[?25l> 1. yes\e[K
+            2. no\e[K
           \e[?25h\e[\e[C
         EOF
         assert_result(expected_out, "", :SIGINT)
@@ -77,11 +74,8 @@ module CLI
 
         expected_out = strip_heredoc(<<-EOF) + ' '
           ? q (choose with ↑ ↓ ⏎)
-          \e[?25l> 1. a
-            2. b
-          \e[\e[C
-          > 1. a
-            2. b
+          \e[?25l> 1. a\e[K
+            2. b\e[K
           \e[?25h\e[\e[C
         EOF
         assert_result(expected_out, "", :SIGINT)
@@ -91,8 +85,8 @@ module CLI
         _run('y') { assert Prompt.confirm('q') }
         expected_out = strip_heredoc(<<-EOF) + ' '
           ? q (choose with ↑ ↓ ⏎)
-          \e[?25l> 1. yes
-            2. no
+          \e[?25l> 1. yes\e[K
+            2. no\e[K
           \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}
@@ -107,11 +101,8 @@ module CLI
         _run(%w(r y n)) { Prompt.confirm('q') }
         expected_out = strip_heredoc(<<-EOF) + ' '
           ? q (choose with ↑ ↓ ⏎)
-          \e[?25l> 1. yes
-            2. no
-          \e[\e[C
-          > 1. yes
-            2. no
+          \e[?25l> 1. yes\e[K
+            2. no\e[K
           \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}
@@ -126,11 +117,8 @@ module CLI
         _run('x', 'n') { Prompt.confirm('q') }
         expected_out = strip_heredoc(<<-EOF) + ' '
           ? q (choose with ↑ ↓ ⏎)
-          \e[?25l> 1. yes
-            2. no
-          \e[\e[C
-          > 1. yes
-            2. no
+          \e[?25l> 1. yes\e[K
+            2. no\e[K
           \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}
@@ -229,8 +217,8 @@ module CLI
         end
         expected_out = strip_heredoc(<<-EOF)
           ? q (choose with ↑ ↓ ⏎)
-          \e[?25l> 1. a
-            2. b
+          \e[?25l> 1. a\e[K
+            2. b\e[K
           \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}
@@ -247,8 +235,8 @@ module CLI
         end
         expected_out = strip_heredoc(<<-EOF)
           ? q (choose with ↑ ↓ ⏎)
-          \e[?25l> 1. a
-            2. b
+          \e[?25l> 1. a\e[K
+            2. b\e[K
           \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}
@@ -265,11 +253,11 @@ module CLI
         end
         expected_out = strip_heredoc(<<-EOF)
         ? q (choose with ↑ ↓ ⏎)
-        \e[?25l> 1. a
-          2. b
+        \e[?25l> 1. a\e[K
+          2. b\e[K
         \e[\e[C
-          1. a
-        > 2. b
+          1. a\e[K
+        > 2. b\e[K
         \e[\e[C
         #{' ' * CLI::UI::Terminal.width}
         #{' ' * CLI::UI::Terminal.width}
@@ -286,8 +274,8 @@ module CLI
         end
         expected_out = strip_heredoc(<<-EOF)
         ? q (choose with ↑ ↓ ⏎)
-        \e[?25l> 1. a
-          2. b
+        \e[?25l> 1. a\e[K
+          2. b\e[K
         \e[\e[C
         #{' ' * CLI::UI::Terminal.width}
         #{' ' * CLI::UI::Terminal.width}
@@ -309,11 +297,8 @@ module CLI
 
         expected_out = strip_heredoc(<<-EOF)
         ? q (choose with ↑ ↓ ⏎)
-        \e[?25l> 1. a
-          2. b
-        \e[\e[C
-        > 1. a
-          2. b
+        \e[?25l> 1. a\e[K
+          2. b\e[K
         \e[?25h\e[\e[C
         EOF
         assert_result(expected_out, nil, :SIGINT)
@@ -325,20 +310,8 @@ module CLI
         end
         expected_out = strip_heredoc(<<-EOF)
         ? q (choose with ↑ ↓ ⏎)
-        \e[?25l> 1. a
-          2. b
-        \e[\e[C
-        > 1. a
-          2. b
-        \e[\e[C
-        > 1. a
-          2. b
-        \e[\e[C
-        > 1. a
-          2. b
-        \e[\e[C
-        > 1. a
-          2. b
+        \e[?25l> 1. a\e[K
+          2. b\e[K
         \e[\e[C
         #{' ' * CLI::UI::Terminal.width}
         #{' ' * CLI::UI::Terminal.width}
@@ -359,14 +332,14 @@ module CLI
         blank = ''
         expected_out = strip_heredoc(<<-EOF)
           ? q (choose with ↑ ↓ ⏎)
-          \e[?25l> 1. a
-            2.#{blank}
+          \e[?25l> 1. a\e[K
+            2.#{blank}\e[K
           \e[\e[C
-            1. a
-          > 2.#{blank}
+            1. a\e[K
+          > 2.#{blank}\e[K
           \e[\e[C
-          > 1. a
-            2.#{blank}
+          > 1. a\e[K
+            2.#{blank}\e[K
           \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}


### PR DESCRIPTION
Implement a scrolling list.  `wait_for_actionable_user_input` stops re-rendering options when not necessary (midway through processing a ⬆️/⬇️ sequence) since it was causing some noticeable flicker, but also means that tests had to change more, since fewer lines are written.  `fmt_full_line` is needed now since the lengths of lines can change, which was not true before since the only thing that changed was the marker vs space and colour.  This also caused tests to change, prompting the `option_text` helper.

![screen shot 2018-05-31 at 3 18 04 pm](https://user-images.githubusercontent.com/6557101/40803179-f17fb5a4-64e5-11e8-85f2-62f5f5d14c95.png)

![screen shot 2018-05-31 at 3 18 13 pm](https://user-images.githubusercontent.com/6557101/40803198-fddb17d0-64e5-11e8-98a4-6de76d3aa749.png)

![screen shot 2018-05-31 at 3 18 21 pm](https://user-images.githubusercontent.com/6557101/40803203-0333e25c-64e6-11e8-9f11-0c8097a70a5f.png)

![screen shot 2018-05-31 at 3 18 31 pm](https://user-images.githubusercontent.com/6557101/40803208-06b141b8-64e6-11e8-984d-cf571af0139a.png)

cc @Shopify/dev-infra 
Fixes #34