### PR TITLE
Add a truncater to prevent overlength output cascades in spingroup

### DIFF
--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -8,6 +8,7 @@ module CLI
     autoload :Progress,           'cli/ui/progress'
     autoload :Prompt,             'cli/ui/prompt'
     autoload :Terminal,           'cli/ui/terminal'
+    autoload :Truncater,          'cli/ui/truncater'
     autoload :Formatter,          'cli/ui/formatter'
     autoload :Spinner,            'cli/ui/spinner'
 
@@ -68,10 +69,13 @@ module CLI
     # ==== Attributes
     #
     # * +input+ - input to format
+    # * +truncate_to+ - number of characters to truncate the string to (or nil)
     #
-    def self.resolve_text(input)
+    def self.resolve_text(input, truncate_to: nil)
       return input if input.nil?
-      CLI::UI::Formatter.new(input).format
+      formatted = CLI::UI::Formatter.new(input).format
+      return formatted unless truncate_to
+      return CLI::UI::Truncater.call(formatted, truncate_to)
     end
 
     # Conviencence Method to format text using +CLI::UI::Formatter.format+

--- a/lib/cli/ui/truncater.rb
+++ b/lib/cli/ui/truncater.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'cli/ui'
+
+module CLI
+  module UI
+    # Truncater truncates a string to a provided printable width.
+    module Truncater
+      PARSE_ROOT = :root
+      PARSE_ANSI = :ansi
+      PARSE_ESC  = :esc
+      PARSE_ZWJ  = :zwj
+
+      ESC                 = 0x1b
+      LEFT_SQUARE_BRACKET = 0x5b
+      ZWJ                 = 0x200d # emojipedia.org/emoji-zwj-sequences
+      SEMICOLON           = 0x3b
+
+      # EMOJI_RANGE in particular is super inaccurate. This is best-effort.
+      # Make it better if you need it better.
+      EMOJI_RANGE    = 0x1f300..0x1f5ff
+      NUMERIC_RANGE  = 0x30..0x39
+      LC_ALPHA_RANGE = 0x40..0x5a
+      UC_ALPHA_RANGE = 0x60..0x71
+
+      TRUNCATED = "\x1b[0m…"
+
+      class << self
+        def call(text, printing_width)
+          return text if text.size <= printing_width
+
+          width            = 0
+          mode             = PARSE_ROOT
+          truncation_index = nil
+
+          codepoints = text.codepoints
+          codepoints.each.with_index do |cp, index|
+            case mode
+            when PARSE_ROOT
+              case cp
+              when ESC # non-printable, followed by some more non-printables.
+                mode = PARSE_ESC
+              when ZWJ # non-printable, followed by another non-printable.
+                mode = PARSE_ZWJ
+              else
+                width += width(cp)
+                case width <=> printing_width
+                when -1
+                when 0
+                  truncation_index ||= index
+                when 1
+                  truncation_index ||= index
+                end
+              end
+            when PARSE_ESC
+              case cp
+              when LEFT_SQUARE_BRACKET
+                mode = PARSE_ANSI
+              else
+                mode = PARSE_ROOT
+              end
+            when PARSE_ANSI
+              # ANSI escape codes preeeetty much have the format of:
+              # \x1b[0-9;]+[A-Za-z]
+              case cp
+              when NUMERIC_RANGE, SEMICOLON
+              when LC_ALPHA_RANGE, UC_ALPHA_RANGE
+                mode = PARSE_ROOT
+              end
+            when PARSE_ZWJ
+              # consume any character and consider it as having no width
+              # width(x+ZWJ+y) = width(x).
+              mode = PARSE_ROOT
+            end
+          end
+
+          return text if !truncation_index || width <= printing_width
+
+          codepoints[0...truncation_index].pack("U*") + TRUNCATED
+        end
+
+        private
+
+        def width(printable_codepoint)
+          case printable_codepoint
+          when EMOJI_RANGE
+            2
+          else
+            1
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/cli/ui/truncater_test.rb
+++ b/test/cli/ui/truncater_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+module CLI
+  module UI
+    class TruncaterTest < MiniTest::Test
+
+      MAN     = "\u{1f468}" # width=2
+      COOKING = "\u{1f373}" # width=2
+      ZWJ     = "\u{200d}"  # width=complicated
+
+      MAN_COOKING = MAN + ZWJ + COOKING # width=2
+
+      def test_truncate
+        assert_example(3, "foobar", "fo\x1b[0m…")
+        assert_example(5, "foobar", "foob\x1b[0m…")
+        assert_example(6, "foobar", "foobar")
+        assert_example(6, "foo\x1b[31mbar\x1b[0m", "foo\x1b[31mbar\x1b[0m")
+        assert_example(6, "\x1b[31mfoobar", "\x1b[31mfoobar")
+        assert_example(3, MAN_COOKING + MAN_COOKING, MAN_COOKING + Truncater::TRUNCATED)
+        assert_example(3, "A" + MAN_COOKING, "A" + MAN_COOKING)
+        assert_example(3, "AB" + MAN_COOKING, "AB" + Truncater::TRUNCATED)
+      end
+
+      private
+
+      def assert_example(width, from, to)
+        truncated = CLI::UI::Truncater.call(from, width)
+        assert_equal(to.codepoints.map{|c|c.to_s(16)}, truncated.codepoints.map{|c|c.to_s(16)})
+      end
+    end
+  end
+end


### PR DESCRIPTION
![screen shot 2018-06-29 at 4 20 48 pm](https://user-images.githubusercontent.com/1284/42113194-707cecb2-7bb8-11e8-9487-2663b52fe015.png)

