### PR TITLE
Fix ansi problem

### DIFF
--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -145,12 +145,6 @@ module CLI
         cursor_up + control('1', 'G')
       end
 
-      # Move to the end of the line
-      #
-      def self.end_of_line
-        control("\033[", 'C')
-      end
-
       def self.clear_to_end_of_line
         control('', 'K')
       end

--- a/lib/cli/ui/progress.rb
+++ b/lib/cli/ui/progress.rb
@@ -36,7 +36,6 @@ module CLI
         puts bar.to_s
         CLI::UI.raw do
           print(ANSI.show_cursor)
-          puts(ANSI.previous_line + ANSI.end_of_line)
         end
       end
 
@@ -67,8 +66,7 @@ module CLI
         @percent_done = [@percent_done, 1.0].min # Make sure we can't go above 1.0
 
         print to_s
-        print CLI::UI::ANSI.previous_line
-        print CLI::UI::ANSI.end_of_line + "\n"
+        print CLI::UI::ANSI.previous_line + "\n"
       end
 
       # Format the progress bar to be printed to terminal

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -135,12 +135,12 @@ module CLI
           puts_question("#{question} {{yellow:(#{instructions})}}")
           resp = interactive_prompt(options, multiple: multiple)
 
-          # Clear the line, and reset the question to include the answer
-          print(ANSI.previous_line + ANSI.end_of_line + ' ')
-          print(ANSI.cursor_save)
-          print(' ' * CLI::UI::Terminal.width)
-          print(ANSI.cursor_restore)
+          # Clear the line
+          print ANSI.previous_line + ANSI.clear_to_end_of_line
+          # Force StdoutRouter to prefix
+          print ANSI.previous_line + "\n"
 
+          # reset the question to include the answer
           resp_text = resp
           if multiple
             resp_text = case resp.size

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -63,7 +63,6 @@ module CLI
         ensure
           CLI::UI.raw do
             print(ANSI.show_cursor)
-            puts(ANSI.previous_line + ANSI.end_of_line)
           end
         end
 
@@ -74,7 +73,6 @@ module CLI
           # When we redraw the options, they will be overwritten
           CLI::UI.raw do
             num_lines.times { print(ANSI.previous_line) }
-            print(ANSI.previous_line + ANSI.end_of_line + "\n")
           end
         end
 

--- a/test/cli/ui/progress_test.rb
+++ b/test/cli/ui/progress_test.rb
@@ -39,7 +39,7 @@ module CLI
           assert_equal expected_bar, bar.to_s
         end
 
-        assert_equal expected_bar + "\e[1A\e[1G\e[\e[C\n", out
+        assert_equal expected_bar + "\e[1A\e[1G\n", out
       end
     end
   end

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -39,7 +39,7 @@ module CLI
           ? q (Choose with ↑ ↓ ⏎)
           \e[?25l> 1. yes\e[K
             2. no\e[K
-          \e[?25h\e[\e[C
+          \e[?25h
         EOF
         assert_result(expected_out, "", :SIGINT)
       end
@@ -76,7 +76,7 @@ module CLI
           ? q (Choose with ↑ ↓ ⏎)
           \e[?25l> 1. a\e[K
             2. b\e[K
-          \e[?25h\e[\e[C
+          \e[?25h
         EOF
         assert_result(expected_out, "", :SIGINT)
       end
@@ -87,12 +87,10 @@ module CLI
           ? q (Choose with ↑ ↓ ⏎)
           \e[?25l> 1. yes\e[K
             2. no\e[K
-          \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}
-          \e[\e[C
-          \e[?25h\e[\e[C
-          \e[\e[C \e[s#{' ' * CLI::UI::Terminal.width}\e[u? q (You chose: yes)
+          \e[?25h\e[K
+          ? q (You chose: yes)
         EOF
         assert_result(expected_out, "", true)
       end
@@ -103,12 +101,10 @@ module CLI
           ? q (Choose with ↑ ↓ ⏎)
           \e[?25l> 1. yes\e[K
             2. no\e[K
-          \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}
-          \e[\e[C
-          \e[?25h\e[\e[C
-          \e[\e[C \e[s#{' ' * CLI::UI::Terminal.width}\e[u? q (You chose: yes)
+          \e[?25h\e[K
+          ? q (You chose: yes)
         EOF
         assert_result(expected_out, "", true)
       end
@@ -119,12 +115,10 @@ module CLI
           ? q (Choose with ↑ ↓ ⏎)
           \e[?25l> 1. yes\e[K
             2. no\e[K
-          \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}
-          \e[\e[C
-          \e[?25h\e[\e[C
-          \e[\e[C \e[s#{' ' * CLI::UI::Terminal.width}\e[u? q (You chose: no)
+          \e[?25h\e[K
+          ? q (You chose: no)
         EOF
         assert_result(expected_out, "", false)
       end
@@ -219,12 +213,10 @@ module CLI
           ? q (Choose with ↑ ↓ ⏎)
           \e[?25l> 1. a\e[K
             2. b\e[K
-          \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}
-          \e[\e[C
-          \e[?25h\e[\e[C
-          \e[\e[C \e[s#{' ' * CLI::UI::Terminal.width}\e[u? q (You chose: b)
+          \e[?25h\e[K
+          ? q (You chose: b)
         EOF
         assert_result(expected_out, "", "b was selected")
       end
@@ -237,12 +229,10 @@ module CLI
           ? q (Choose with ↑ ↓ ⏎)
           \e[?25l> 1. a\e[K
             2. b\e[K
-          \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}
-          \e[\e[C
-          \e[?25h\e[\e[C
-          \e[\e[C \e[s#{' ' * CLI::UI::Terminal.width}\e[u? q (You chose: b)
+          \e[?25h\e[K
+          ? q (You chose: b)
         EOF
         assert_result(expected_out, "", "b")
       end
@@ -255,15 +245,12 @@ module CLI
         ? q (Choose with ↑ ↓ ⏎)
         \e[?25l> 1. a\e[K
           2. b\e[K
-        \e[\e[C
           1. a\e[K
         > 2. b\e[K
-        \e[\e[C
         #{' ' * CLI::UI::Terminal.width}
         #{' ' * CLI::UI::Terminal.width}
-        \e[\e[C
-        \e[?25h\e[\e[C
-        \e[\e[C \e[s#{' ' * CLI::UI::Terminal.width}\e[u? q (You chose: b)
+        \e[?25h\e[K
+        ? q (You chose: b)
         EOF
         assert_result(expected_out, "", "b")
       end
@@ -276,12 +263,10 @@ module CLI
         ? q (Choose with ↑ ↓ ⏎)
         \e[?25l> 1. a\e[K
           2. b\e[K
-        \e[\e[C
         #{' ' * CLI::UI::Terminal.width}
         #{' ' * CLI::UI::Terminal.width}
-        \e[\e[C
-        \e[?25h\e[\e[C
-        \e[\e[C \e[s#{' ' * CLI::UI::Terminal.width}\e[u? q (You chose: a)
+        \e[?25h\e[K
+        ? q (You chose: a)
         EOF
         assert_result(expected_out, "", "a")
       end
@@ -299,7 +284,7 @@ module CLI
         ? q (Choose with ↑ ↓ ⏎)
         \e[?25l> 1. a\e[K
           2. b\e[K
-        \e[?25h\e[\e[C
+        \e[?25h
         EOF
         assert_result(expected_out, nil, :SIGINT)
       end
@@ -312,12 +297,10 @@ module CLI
         ? q (Choose with ↑ ↓ ⏎)
         \e[?25l> 1. a\e[K
           2. b\e[K
-        \e[\e[C
         #{' ' * CLI::UI::Terminal.width}
         #{' ' * CLI::UI::Terminal.width}
-        \e[\e[C
-        \e[?25h\e[\e[C
-        \e[\e[C \e[s#{' ' * CLI::UI::Terminal.width}\e[u? q (You chose: b)
+        \e[?25h\e[K
+        ? q (You chose: b)
         EOF
         assert_result(expected_out, "", "b")
       end
@@ -334,18 +317,14 @@ module CLI
           ? q (Choose with ↑ ↓ ⏎)
           \e[?25l> 1. a\e[K
             2.#{blank}\e[K
-          \e[\e[C
             1. a\e[K
           > 2.#{blank}\e[K
-          \e[\e[C
           > 1. a\e[K
             2.#{blank}\e[K
-          \e[\e[C
           #{' ' * CLI::UI::Terminal.width}
           #{' ' * CLI::UI::Terminal.width}
-          \e[\e[C
-          \e[?25h\e[\e[C
-          \e[\e[C \e[s#{' ' * CLI::UI::Terminal.width}\e[u? q (You chose: a)
+          \e[?25h\e[K
+          ? q (You chose: a)
         EOF
         assert_result(expected_out, "", "a was selected")
       end


### PR DESCRIPTION
`CLI::UI::ANSI.end_of_line` was broken in a couple of ways.  First, it didn't actually move to the end of the line, it advanced the cursor by one place.  Second, it was printing an extra escape sequence opener to do so (`\e[\e[C` instead of `\e[C`).  Some terminals were ignoring this invalid output, but others showed a character for it.

Given it wasn't doing the job it advertised, and that I could not find a trivial sequence that would, and where it was being used it clearly wasn't needed since it wasn't doing the job we thought it was, I removed it, and adjusted the places where it was being used.

Fixes #39.