### PR TITLE
Add flag to `confirm` that puts "no" first

### DIFF
--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -48,8 +48,8 @@ module CLI
     #
     # * +question+ - question to confirm
     #
-    def self.confirm(question)
-      CLI::UI::Prompt.confirm(question)
+    def self.confirm(question, **kwargs)
+      CLI::UI::Prompt.confirm(question, **kwargs)
     end
 
     # Conviencence Method for +CLI::UI::Prompt.ask+

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -91,8 +91,10 @@ module CLI
         # Confirmation question
         #   CLI::UI::Prompt.confirm('Is the sky blue?')
         #
-        def confirm(question)
-          ask_interactive(question, %w(yes no)) == 'yes'
+        #   CLI::UI::Prompt.confirm('Do a dangerous thing?', default_yes: false)
+        #
+        def confirm(question, default_yes: true)
+          ask_interactive(question, default_yes ? %w(yes no) : %w(no yes)) == 'yes'
         end
 
         private

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -91,10 +91,10 @@ module CLI
         # Confirmation question
         #   CLI::UI::Prompt.confirm('Is the sky blue?')
         #
-        #   CLI::UI::Prompt.confirm('Do a dangerous thing?', default_yes: false)
+        #   CLI::UI::Prompt.confirm('Do a dangerous thing?', default: false)
         #
-        def confirm(question, default_yes: true)
-          ask_interactive(question, default_yes ? %w(yes no) : %w(no yes)) == 'yes'
+        def confirm(question, default: true)
+          ask_interactive(question, default ? %w(yes no) : %w(no yes)) == 'yes'
         end
 
         private

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -96,7 +96,7 @@ module CLI
       end
 
       def test_confirm_default_no
-        _run("\n") { Prompt.confirm('q', default_yes: false) }
+        _run("\n") { Prompt.confirm('q', default: false) }
 
         expected_out = strip_heredoc(<<-EOF) + ' '
           ? q (Choose with ↑ ↓ ⏎)

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -95,6 +95,22 @@ module CLI
         assert_result(expected_out, "", true)
       end
 
+      def test_confirm_default_no
+        _run("\n") { Prompt.confirm('q', default_yes: false) }
+
+        expected_out = strip_heredoc(<<-EOF) + ' '
+          ? q (Choose with ↑ ↓ ⏎)
+          \e[?25l> 1. no\e[K
+            2. yes\e[K
+          #{' ' * CLI::UI::Terminal.width}
+          #{' ' * CLI::UI::Terminal.width}
+          \e[?25h\e[K
+          ? q (You chose: no)
+        EOF
+
+        assert_result(expected_out, "", false)
+      end
+
       def test_confirm_invalid
         _run(%w(r y n)) { Prompt.confirm('q') }
         expected_out = strip_heredoc(<<-EOF) + ' '


### PR DESCRIPTION
This is something of a convenience that I've started emulating for "dangerous" options in a couple of tools I help maintain.

Figured it might be useful to other people.