### PR TITLE
No brace counting

### DIFF
--- a/cli-ui.gemspec
+++ b/cli-ui.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  # spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/lib/cli/ui/formatter.rb
+++ b/lib/cli/ui/formatter.rb
@@ -171,7 +171,7 @@ module CLI
         elsif match && match.end_with?(END_EXPR)
           @brace_counter -= 1
           emit(match[DISCARD_BRACES], stack)
-          if stack.empty? or stack.pop == LITERAL_BRACES
+          if stack.pop == LITERAL_BRACES
             emit('}}', stack)
             @brace_counter += 1 # Prevent literal braces from decreasing the counter
           end

--- a/lib/cli/ui/formatter.rb
+++ b/lib/cli/ui/formatter.rb
@@ -69,9 +69,6 @@ module CLI
       #
       def initialize(text)
         @text = text
-        # Used to keep track of opening braces to detect mismatched braces
-        # in the input string.
-        @brace_counter = 0
       end
 
       # Format the text using a map.
@@ -87,11 +84,6 @@ module CLI
       def format(sgr_map = SGR_MAP, enable_color: CLI::UI.enable_color?)
         @nodes = []
         stack = parse_body(StringScanner.new(@text))
-        if @brace_counter > 0
-          raise FormatError.new('Mismatched braces in input',
-                                @text,
-                                -1)
-        end
         prev_fmt = nil
         content = @nodes.each_with_object(+'') do |(text, fmt), str|
           if prev_fmt != fmt && enable_color
@@ -136,8 +128,6 @@ module CLI
           begin
             glyph = Glyph.lookup(glyph_handle)
             emit(glyph.char, [glyph.color.name.to_s])
-            # Glyphs match on their closing braces, so we have to decrease the count here
-            @brace_counter -= 1
           rescue Glyph::InvalidGlyphHandle
             index = sc.pos - 2 # rewind past '}}'
             raise FormatError.new(
@@ -156,7 +146,6 @@ module CLI
           # pairs of {{ }} at least.
           emit('{{', stack)
           stack.push(LITERAL_BRACES)
-          @brace_counter -= 1 # Don't count literal opening braces
         end
         parse_body(sc, stack)
         stack
@@ -165,15 +154,12 @@ module CLI
       def parse_body(sc, stack = [])
         match = sc.scan(SCAN_BODY)
         if match && match.end_with?(BEGIN_EXPR)
-          @brace_counter += 1
           emit(match[DISCARD_BRACES], stack)
           parse_expr(sc, stack)
         elsif match && match.end_with?(END_EXPR)
-          @brace_counter -= 1
           emit(match[DISCARD_BRACES], stack)
           if stack.pop == LITERAL_BRACES
             emit('}}', stack)
-            @brace_counter += 1 # Prevent literal braces from decreasing the counter
           end
           parse_body(sc, stack)
         elsif match

--- a/test/cli/ui/formatter_test.rb
+++ b/test/cli/ui/formatter_test.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 require 'test_helper'
 
 module CLI
@@ -12,7 +11,7 @@ module CLI
       end
 
       def test_format_no_color
-        input = "a{{blue:b {{*}}{{bold:c {{red:d}}}}{{bold: e}}}} f {{bold:}}"
+        input = "a{{blue:b {{*}}{{bold:c {{red:d}}}}{{bold: e}}}} f {{bold:"
         expected = "ab ⭑c d e f "
         actual = CLI::UI::Formatter.new(input).format(enable_color: false)
         assert_equal(expected, actual)
@@ -20,13 +19,9 @@ module CLI
 
       def test_format_trailing
         input = "a{{bold:a {{blue:"
-        ex = assert_raises(CLI::UI::Formatter::FormatError) do
-          CLI::UI::Formatter.new(input).format
-        end
-        expected = 'Mismatched braces in input'
-        assert_equal(input, ex.input)
-        assert_equal(-1, ex.index)
-        assert_equal(expected, ex.message)
+        expected = "\e[0ma\e[0;1ma \e[0;1;94m"
+        actual = CLI::UI::Formatter.new(input).format
+        assert_equal(expected, actual)
       end
 
       def test_invalid_funcname

--- a/test/cli/ui/formatter_test.rb
+++ b/test/cli/ui/formatter_test.rb
@@ -29,38 +29,6 @@ module CLI
         assert_equal(expected, ex.message)
       end
 
-      def test_out_of_order_braces
-        input = '}}{{blue:foo'
-        ex = assert_raises(CLI::UI::Formatter::FormatError) do
-          CLI::UI::Formatter.new(input).format
-        end
-        expected = 'Mismatched braces in input'
-        assert_equal(input, ex.input)
-        assert_equal(-1, ex.index)
-        assert_equal(expected, ex.message)
-      end
-
-      def test_leading_literal_closing_braces
-        input = '}} foo'
-        expected = "\e[0m}} foo"
-        actual = CLI::UI::Formatter.new(input).format
-        assert_equal(expected, actual)
-      end
-
-      def test_trailing_literal_closing_braces
-        input = 'foo}}'
-        expected = "\e[0mfoo}}"
-        actual = CLI::UI::Formatter.new(input).format
-        assert_equal(expected, actual)
-      end
-
-      def test_extra_closing_braces
-        input = '{{blue:foo}}}}'
-        expected = "\e[0;94mfoo\e[0m}}"
-        actual = CLI::UI::Formatter.new(input).format
-        assert_equal(expected, actual)
-      end
-
       def test_invalid_funcname
         input = "{{nope:text}}"
         ex = assert_raises(CLI::UI::Formatter::FormatError) do


### PR DESCRIPTION
When we updated this in `dev`, we found a legitimate use-case for mismatched braces, which had a useful behaviour:

We, in some cases, split a message with format codes on newline and emit each line independently. Format codes are allowed to span multiple lines and seem to work as you might expect, and brace counting causes :boom: in these cases.

IMO I'm not totally against revising our code to do better at this but I don't really feel like this runtime check provides enough value to carry its weight.