### PR TITLE
Fixes #63 by ignoring left and right keypresses

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -288,6 +288,8 @@ module CLI
             case char
             when 'A'      ; up
             when 'B'      ; down
+            when 'C'      ; # Ignore right key
+            when 'D'      ; # Ignore left key
             else          ; raise Interrupt # unhandled escape sequence.
             end
           end


### PR DESCRIPTION
Implemented simple fix by just having the left and right key inputs ignored so they don't drop into the `else` clause where an exception is raised.