### PR TITLE
Add a puts method

### DIFF
--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -5,6 +5,7 @@ module CLI
     autoload :Color,              'cli/ui/color'
     autoload :Box,                'cli/ui/box'
     autoload :Frame,              'cli/ui/frame'
+    autoload :Printer,            'cli/ui/printer'
     autoload :Progress,           'cli/ui/progress'
     autoload :Prompt,             'cli/ui/prompt'
     autoload :Terminal,           'cli/ui/terminal'
@@ -95,6 +96,17 @@ module CLI
     #
     def self.fmt(input, enable_color: enable_color?)
       CLI::UI::Formatter.new(input).format(enable_color: enable_color)
+    end
+
+    # Convenience Method for +CLI::UI::Printer.puts+
+    #
+    # ==== Attributes
+    #
+    # * +msg+ - Message to print
+    # * +kwargs+ - keyword arguments for +Printer.puts+
+    #
+    def self.puts(msg, **kwargs)
+      CLI::UI::Printer.puts(msg, **kwargs)
     end
 
     # Convenience Method for +CLI::UI::Frame.open+

--- a/lib/cli/ui/printer.rb
+++ b/lib/cli/ui/printer.rb
@@ -17,7 +17,11 @@ module CLI
       # * +:to+ - Target stream, like $stdout or $stderr. Can be anything with a puts method. Defaults to $stdout.
       # * +:encoding+ - Force the output to be in a certain encoding. Defaults to UTF-8.
       # * +:format+ - Whether to format the string using CLI::UI.fmt. Defaults to true.
-      # * +:graceful+ - Whether to gracefully rescue common I/O errors. Defaults to true.
+      # * +:graceful+ - Whether to gracefully ignore common I/O errors. Defaults to true.
+      #
+      # ==== Returns
+      # Returns whether the message was successfully printed,
+      # which can be useful if +:graceful+ is set to true.
       #
       # ==== Example
       #

--- a/lib/cli/ui/printer.rb
+++ b/lib/cli/ui/printer.rb
@@ -1,0 +1,43 @@
+require 'cli/ui'
+
+module CLI
+  module UI
+    class Printer
+      # Print a message to a stream with common utilities.
+      # Allows overriding the color, encoding, and target stream.
+      # By default, it formats the string using CLI:UI and rescues common stream errors.
+      #
+      # ==== Attributes
+      #
+      # * +msg+ - (required) the string to output. Can be frozen.
+      #
+      # ==== Options
+      #
+      # * +:frame_color+ - Override the frame color. Defaults to nil.
+      # * +:stream+ - Target stream, like $stdout or $stderr. Can be anything with a puts method. Defaults to $stdout.
+      # * +:encoding+ - Force the output to be in a certain encoding. Defaults to UTF-8.
+      # * +:format+ - Whether to format the string using CLI::UI.fmt. Defaults to true.
+      # * +:graceful+ - Whether to gracefully rescue common I/O errors. Defaults to true.
+      #
+      # ==== Example
+      #
+      #   CLI::UI::Printer.puts('{x} Ouch', stream: $stderr, color: :red)
+      #
+      def self.puts(msg, frame_color: nil, stream: $stdout, encoding: Encoding::UTF_8, format: true, graceful: true)
+        msg = (+msg).force_encoding(encoding) if encoding
+        msg = CLI::UI.fmt(msg) if format
+
+        if frame_color
+          CLI::UI::Frame.with_frame_color_override(frame_color) { stream.puts(msg) }
+        else
+          stream.puts(msg)
+        end
+
+        true
+      rescue Errno::EIO, Errno::EPIPE, IOError => e
+        raise(e) unless graceful
+        false
+      end
+    end
+  end
+end

--- a/lib/cli/ui/printer.rb
+++ b/lib/cli/ui/printer.rb
@@ -14,7 +14,7 @@ module CLI
       # ==== Options
       #
       # * +:frame_color+ - Override the frame color. Defaults to nil.
-      # * +:stream+ - Target stream, like $stdout or $stderr. Can be anything with a puts method. Defaults to $stdout.
+      # * +:to+ - Target stream, like $stdout or $stderr. Can be anything with a puts method. Defaults to $stdout.
       # * +:encoding+ - Force the output to be in a certain encoding. Defaults to UTF-8.
       # * +:format+ - Whether to format the string using CLI::UI.fmt. Defaults to true.
       # * +:graceful+ - Whether to gracefully rescue common I/O errors. Defaults to true.
@@ -23,14 +23,14 @@ module CLI
       #
       #   CLI::UI::Printer.puts('{x} Ouch', stream: $stderr, color: :red)
       #
-      def self.puts(msg, frame_color: nil, stream: $stdout, encoding: Encoding::UTF_8, format: true, graceful: true)
+      def self.puts(msg, frame_color: nil, to: $stdout, encoding: Encoding::UTF_8, format: true, graceful: true)
         msg = (+msg).force_encoding(encoding) if encoding
         msg = CLI::UI.fmt(msg) if format
 
         if frame_color
-          CLI::UI::Frame.with_frame_color_override(frame_color) { stream.puts(msg) }
+          CLI::UI::Frame.with_frame_color_override(frame_color) { to.puts(msg) }
         else
-          stream.puts(msg)
+          to.puts(msg)
         end
 
         true

--- a/test/cli/ui/printer_test.rb
+++ b/test/cli/ui/printer_test.rb
@@ -6,7 +6,7 @@ module CLI
       def test_puts_color
         out, _ = capture_io do
           CLI::UI::StdoutRouter.ensure_activated
-          Printer.puts('foo', frame_color: :red)
+          assert(Printer.puts('foo', frame_color: :red))
         end
 
         assert_equal("\e[0mfoo\n", out)
@@ -16,7 +16,7 @@ module CLI
         Frame.open('test') do
           out, _ = capture_io do
             CLI::UI::StdoutRouter.ensure_activated
-            Printer.puts('foo', frame_color: :red)
+            assert(Printer.puts('foo', frame_color: :red))
           end
 
           assert_equal("\e[31m┃ \e[0m\e[0mfoo\n", out)
@@ -25,7 +25,7 @@ module CLI
 
       def test_puts_stream
         _, err = capture_io do
-          Printer.puts('foo', to: $stderr, format: false)
+          assert(Printer.puts('foo', to: $stderr, format: false))
         end
 
         assert_equal("foo\n", err)
@@ -33,7 +33,7 @@ module CLI
 
       def test_puts_format
         out, _ = capture_io do
-          Printer.puts('{{x}} foo')
+          assert(Printer.puts('{{x}} foo'))
         end
 
         assert_equal("\e[0;31m✗\e[0m foo\n", out)
@@ -41,7 +41,7 @@ module CLI
 
       def test_puts_pipe
         IO.pipe do |r, w|
-          Printer.puts('foo', to: w, format: false)
+          assert(Printer.puts('foo', to: w, format: false))
           assert_equal("foo\n", r.gets)
         end
       end
@@ -58,7 +58,7 @@ module CLI
       def test_puts_graceful
         IO.pipe do |r, w|
           w.close
-          Printer.puts('foo', to: w, graceful: true)
+          refute(Printer.puts('foo', to: w, graceful: true))
           assert_nil(r.gets)
         end
       end
@@ -66,7 +66,7 @@ module CLI
       def test_encoding
         msg = "é".force_encoding(Encoding::ISO_8859_1)
         out, _ = capture_io do
-          Printer.puts(msg, encoding: nil, format: false)
+          assert(Printer.puts(msg, encoding: nil, format: false))
         end
         refute_equal(msg + "\n", out) # It doesn't work
         assert_equal(msg.encode(Encoding::UTF_8) + "\n", out)
@@ -75,7 +75,7 @@ module CLI
       def test_encoding_ut8
         msg = "é".force_encoding(Encoding::ISO_8859_1)
         out, _ = capture_io do
-          Printer.puts(msg, format: false)
+          assert(Printer.puts(msg, format: false))
         end
         assert_equal(msg + "\n", out)
       end

--- a/test/cli/ui/printer_test.rb
+++ b/test/cli/ui/printer_test.rb
@@ -1,0 +1,84 @@
+require 'test_helper'
+
+module CLI
+  module UI
+    class PrinterTest < MiniTest::Test
+      def test_puts_color
+        out, _ = capture_io do
+          CLI::UI::StdoutRouter.ensure_activated
+          Printer.puts('foo', frame_color: :red)
+        end
+
+        assert_equal("\e[0mfoo\n", out)
+      end
+
+      def test_puts_color_frame
+        Frame.open('test') do
+          out, _ = capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+            Printer.puts('foo', frame_color: :red)
+          end
+
+          assert_equal("\e[31m┃ \e[0m\e[0mfoo\n", out)
+        end
+      end
+
+      def test_puts_stream
+        _, err = capture_io do
+          Printer.puts('foo', stream: $stderr, format: false)
+        end
+
+        assert_equal("foo\n", err)
+      end
+
+      def test_puts_format
+        out, _ = capture_io do
+          Printer.puts('{{x}} foo')
+        end
+
+        assert_equal("\e[0;31m✗\e[0m foo\n", out)
+      end
+
+      def test_puts_pipe
+        IO.pipe do |r, w|
+          Printer.puts('foo', stream: w, format: false)
+          assert_equal("foo\n", r.gets)
+        end
+      end
+
+      def test_puts_pipe_closed
+        IO.pipe do |r, w|
+          w.close
+          assert_raises(IOError) do
+            Printer.puts('foo', stream: w, graceful: false)
+          end
+        end
+      end
+
+      def test_puts_graceful
+        IO.pipe do |r, w|
+          w.close
+          Printer.puts('foo', stream: w, graceful: true)
+          assert_nil(r.gets)
+        end
+      end
+
+      def test_encoding
+        msg = "é".force_encoding(Encoding::ISO_8859_1)
+        out, _ = capture_io do
+          Printer.puts(msg, encoding: nil, format: false)
+        end
+        refute_equal(msg + "\n", out) # It doesn't work
+        assert_equal(msg.encode(Encoding::UTF_8) + "\n", out)
+      end
+
+      def test_encoding_ut8
+        msg = "é".force_encoding(Encoding::ISO_8859_1)
+        out, _ = capture_io do
+          Printer.puts(msg, format: false)
+        end
+        assert_equal(msg + "\n", out)
+      end
+    end
+  end
+end

--- a/test/cli/ui/printer_test.rb
+++ b/test/cli/ui/printer_test.rb
@@ -25,7 +25,7 @@ module CLI
 
       def test_puts_stream
         _, err = capture_io do
-          Printer.puts('foo', stream: $stderr, format: false)
+          Printer.puts('foo', to: $stderr, format: false)
         end
 
         assert_equal("foo\n", err)
@@ -41,7 +41,7 @@ module CLI
 
       def test_puts_pipe
         IO.pipe do |r, w|
-          Printer.puts('foo', stream: w, format: false)
+          Printer.puts('foo', to: w, format: false)
           assert_equal("foo\n", r.gets)
         end
       end
@@ -50,7 +50,7 @@ module CLI
         IO.pipe do |r, w|
           w.close
           assert_raises(IOError) do
-            Printer.puts('foo', stream: w, graceful: false)
+            Printer.puts('foo', to: w, graceful: false)
           end
         end
       end
@@ -58,7 +58,7 @@ module CLI
       def test_puts_graceful
         IO.pipe do |r, w|
           w.close
-          Printer.puts('foo', stream: w, graceful: true)
+          Printer.puts('foo', to: w, graceful: true)
           assert_nil(r.gets)
         end
       end


### PR DESCRIPTION
- Print a message to a stream with common utilities.
- Allows overriding the color, encoding, and target stream.
- By default, it formats the string using CLI:UI and rescues common stream errors.

Inspired by https://github.com/Shopify/cli-kit/pull/50