### PR TITLE
Fix interactive option line length calculation

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -97,7 +97,7 @@ module CLI
             width ||= text
                         .split("\n")
                         .reject(&:empty?)
-                        .map { |l| (l.length / max_width).ceil }
+                        .map { |l| (CLI::UI.fmt(l, enable_color: false).length / max_width).ceil }
                         .reduce(&:+)
 
             width


### PR DESCRIPTION
Only include printing characters.

I came across this because a user was seeing odd output behaviour with `dev init`.  In debugging, I saw that she was using Terminal.app and thought it was the culprit.  But it went away when I maximized. Turns out the problem was the default width of Terminal.app of 80 - it misbehaved with a width of 80 or fewer columns. 80 being 80, I chased the wrong things for a while, but it turns out that 80 is the cut off where an option of ` 'Scaffold an entirely new {{bold:project}} with a {{bold:{{green:dev.yml}}}}'` seemed to overflow to a new line if you count all the characters in that string (75) instead of the characters in `'Scaffold an entirely new project with a dev.yml'` (47).