### PR TITLE
Cache More Aggressively in CLI::UI::Terminal

### DIFF
--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -7,13 +7,15 @@ module CLI
       DEFAULT_WIDTH = 80
       DEFAULT_HEIGHT = 24
 
+      @@console = IO.respond_to?(:console) && IO.console
+
       # Returns the width of the terminal, if possible
       # Otherwise will return DEFAULT_WIDTH
       #
       def self.width
         @@width ||= begin
-                      if (console = IO.respond_to?(:console) && IO.console)
-                        width = console.winsize[1]
+                      if @@console
+                        width = @@console.winsize[1]
                         width.zero? ? DEFAULT_WIDTH : width
                       else
                         DEFAULT_WIDTH
@@ -28,8 +30,8 @@ module CLI
       #
       def self.height
         @@height ||= begin
-                       if (console = IO.respond_to?(:console) && IO.console)
-                         height = console.winsize[0]
+                       if @@console
+                         height = @@console.winsize[0]
                          height.zero? ? DEFAULT_HEIGHT : height
                        else
                          DEFAULT_HEIGHT

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -37,7 +37,7 @@ module CLI
       end
 
       def self.setup_winsize_trap
-        @_winsize_trap ||= Signal.trap('WINCH') do
+        @winsize_trap ||= Signal.trap('WINCH') do
           @winsize = nil
         end
       end

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -11,14 +11,14 @@ module CLI
       # Otherwise will return DEFAULT_WIDTH
       #
       def self.width
-        @winsize[1]
+        winsize[1]
       end
 
       # Returns the width of the terminal, if possible
       # Otherwise, will return DEFAULT_HEIGHT
       #
       def self.height
-        @winsize[0]
+        winsize[0]
       end
 
       def self.winsize

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -23,6 +23,9 @@ module CLI
                     end
       end
 
+      # Returns the width of the terminal, if possible
+      # Otherwise, will return 24
+      #
       def self.height
         @@height ||= begin
                        if (console = IO.respond_to?(:console) && IO.console)

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -8,7 +8,7 @@ module CLI
       DEFAULT_HEIGHT = 24
 
       # Returns the width of the terminal, if possible
-      # Otherwise will return 80
+      # Otherwise will return DEFAULT_WIDTH
       #
       def self.width
         @@width ||= begin
@@ -24,7 +24,7 @@ module CLI
       end
 
       # Returns the width of the terminal, if possible
-      # Otherwise, will return 24
+      # Otherwise, will return DEFAULT_HEIGHT
       #
       def self.height
         @@height ||= begin

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -7,52 +7,40 @@ module CLI
       DEFAULT_WIDTH = 80
       DEFAULT_HEIGHT = 24
 
-      @console = begin
-                   IO.respond_to?(:console) && IO.console
-                 rescue Errno::EIO
-                   false
-                 end
-
       # Returns the width of the terminal, if possible
       # Otherwise will return DEFAULT_WIDTH
       #
       def self.width
-        @width ||= begin
-                     if @console
-                       width = @console.winsize[1]
-                       width.zero? ? DEFAULT_WIDTH : width
-                     else
-                       DEFAULT_WIDTH
-                     end
-                   rescue Errno::EIO
-                     DEFAULT_WIDTH
-                   end
+        @winsize[1]
       end
 
       # Returns the width of the terminal, if possible
       # Otherwise, will return DEFAULT_HEIGHT
       #
       def self.height
-        @height ||= begin
-                      if @console
-                        height = @console.winsize[0]
-                        height.zero? ? DEFAULT_HEIGHT : height
-                      else
-                        DEFAULT_HEIGHT
-                      end
-                    rescue Errno::EIO
-                      DEFAULT_HEIGHT
-                    end
+        @winsize[0]
       end
 
-      def self.reset_cache
-        @width = nil
-        @height = nil
+      def self.winsize
+        @winsize ||= begin
+                       winsize = IO.console.winsize
+                       setup_winsize_trap
+
+                       if winsize.any?(&:zero?)
+                         [DEFAULT_HEIGHT, DEFAULT_WIDTH]
+                       else
+                         winsize
+                       end
+                     rescue
+                       [DEFAULT_HEIGHT, DEFAULT_WIDTH]
+                     end
+      end
+
+      def self.setup_winsize_trap
+        @_winsize_trap ||= Signal.trap('WINCH') do
+          @winsize = nil
+        end
       end
     end
   end
-end
-
-Signal.trap('WINCH') do
-  CLI::UI::Terminal.reset_cache
 end

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -7,7 +7,11 @@ module CLI
       DEFAULT_WIDTH = 80
       DEFAULT_HEIGHT = 24
 
-      @@console = IO.respond_to?(:console) && IO.console
+      @@console = begin
+                    IO.respond_to?(:console) && IO.console
+                  rescue Errno::EIO
+                    false
+                  end
 
       # Returns the width of the terminal, if possible
       # Otherwise will return DEFAULT_WIDTH

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -11,26 +11,39 @@ module CLI
       # Otherwise will return 80
       #
       def self.width
-        if (console = IO.respond_to?(:console) && IO.console)
-          width = console.winsize[1]
-          width.zero? ? DEFAULT_WIDTH : width
-        else
-          DEFAULT_WIDTH
-        end
-      rescue Errno::EIO
-        DEFAULT_WIDTH
+        @@width ||= begin
+                      if (console = IO.respond_to?(:console) && IO.console)
+                        width = console.winsize[1]
+                        width.zero? ? DEFAULT_WIDTH : width
+                      else
+                        DEFAULT_WIDTH
+                      end
+                    rescue Errno::EIO
+                      DEFAULT_WIDTH
+                    end
       end
 
       def self.height
-        if (console = IO.respond_to?(:console) && IO.console)
-          height = console.winsize[0]
-          height.zero? ? DEFAULT_HEIGHT : height
-        else
-          DEFAULT_HEIGHT
-        end
-      rescue Errno::EIO
-        DEFAULT_HEIGHT
+        @@height ||= begin
+                       if (console = IO.respond_to?(:console) && IO.console)
+                         height = console.winsize[0]
+                         height.zero? ? DEFAULT_HEIGHT : height
+                       else
+                         DEFAULT_HEIGHT
+                       end
+                     rescue Errno::EIO
+                       DEFAULT_HEIGHT
+                     end
+      end
+
+      def self.reset_cache
+        @@width = nil
+        @@height = nil
       end
     end
   end
+end
+
+Signal.trap('WINCH') do
+  CLI::UI::Terminal.reset_cache
 end

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -7,47 +7,47 @@ module CLI
       DEFAULT_WIDTH = 80
       DEFAULT_HEIGHT = 24
 
-      @@console = begin
-                    IO.respond_to?(:console) && IO.console
-                  rescue Errno::EIO
-                    false
-                  end
+      @console = begin
+                   IO.respond_to?(:console) && IO.console
+                 rescue Errno::EIO
+                   false
+                 end
 
       # Returns the width of the terminal, if possible
       # Otherwise will return DEFAULT_WIDTH
       #
       def self.width
-        @@width ||= begin
-                      if @@console
-                        width = @@console.winsize[1]
-                        width.zero? ? DEFAULT_WIDTH : width
-                      else
-                        DEFAULT_WIDTH
-                      end
-                    rescue Errno::EIO
-                      DEFAULT_WIDTH
-                    end
+        @width ||= begin
+                     if @console
+                       width = @console.winsize[1]
+                       width.zero? ? DEFAULT_WIDTH : width
+                     else
+                       DEFAULT_WIDTH
+                     end
+                   rescue Errno::EIO
+                     DEFAULT_WIDTH
+                   end
       end
 
       # Returns the width of the terminal, if possible
       # Otherwise, will return DEFAULT_HEIGHT
       #
       def self.height
-        @@height ||= begin
-                       if @@console
-                         height = @@console.winsize[0]
-                         height.zero? ? DEFAULT_HEIGHT : height
-                       else
-                         DEFAULT_HEIGHT
-                       end
-                     rescue Errno::EIO
-                       DEFAULT_HEIGHT
-                     end
+        @height ||= begin
+                      if @console
+                        height = @console.winsize[0]
+                        height.zero? ? DEFAULT_HEIGHT : height
+                      else
+                        DEFAULT_HEIGHT
+                      end
+                    rescue Errno::EIO
+                      DEFAULT_HEIGHT
+                    end
       end
 
       def self.reset_cache
-        @@width = nil
-        @@height = nil
+        @width = nil
+        @height = nil
       end
     end
   end


### PR DESCRIPTION
This was brought to my attention by a co-worker.  Well behaved terminals issue a SIGWINCH when the window size changes, so it should be safe to cache width and height values until such a signal is received.

I figured it was safer to simply clear the cache when such a signal is received in case multiple are received in a very short period of time.  My terminal only issues a winch when the terminal has finished resizing, but I didn't think it wise to expect that to be standard behavior.

While I was at it, I wasn't sure if there was a particular reason to look up IO.console each time; It seems like one of those things that will either work or not.  If there was a reason it needed to be looked up constantly, I can pop those commits off.