### PR TITLE
Update rubocop and fix linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-Gemfile.lock
 *.gem
 build
 .vagrant

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,16 @@ inherit_from:
   - http://shopify.github.io/ruby-style-guide/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.1
+  Exclude:
+    - vendor/**/*
+  TargetRubyVersion: 2.3
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# This doesn't understand that <<~ doesn't exist in 2.0
+Layout/IndentHeredoc:
+  Enabled: false
 
 # This doesn't take into account retrying from an exception
 Lint/HandleExceptions:
@@ -14,4 +23,12 @@ Style/EmptyLiteral:
 
 # allow the use of globals which makes sense in a CLI app like this
 Style/GlobalVars:
+  Enabled: false
+
+# allow using %r{} for regexes
+Style/RegexpLiteral:
+  Enabled: false
+
+# allow readable Dev::Util.begin formatting
+Style/MultilineBlockChain:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.3
-before_install: gem install bundler -v 1.15.0
+before_install: gem install bundler -v 1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,53 @@
+PATH
+  remote: .
+  specs:
+    cli-ui (1.3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ansi (1.5.0)
+    ast (2.4.0)
+    builder (3.2.3)
+    byebug (11.0.0)
+    jaro_winkler (1.5.3)
+    metaclass (0.0.4)
+    method_source (0.9.2)
+    minitest (5.11.3)
+    minitest-reporters (1.1.14)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
+    mocha (1.5.0)
+      metaclass (~> 0.0.1)
+    parallel (1.17.0)
+    parser (2.6.4.0)
+      ast (~> 2.4.0)
+    rainbow (3.0.0)
+    rake (12.3.3)
+    rubocop (0.74.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.6)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    ruby-progressbar (1.10.1)
+    unicode-display_width (1.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  byebug
+  cli-ui!
+  method_source
+  minitest (>= 5.0.0)
+  minitest-reporters
+  mocha
+  rake (~> 12.3)
+  rubocop
+
+BUNDLED WITH
+   1.17.3

--- a/Rakefile
+++ b/Rakefile
@@ -17,4 +17,4 @@ RuboCop::RakeTask.new(:style) do |t|
   t.options = ['--display-cop-names']
 end
 
-task(default: [:test])
+task(default: [:test, :style])

--- a/Rakefile
+++ b/Rakefile
@@ -17,4 +17,4 @@ RuboCop::RakeTask.new(:style) do |t|
   t.options = ['--display-cop-names']
 end
 
-task default: [:test]
+task(default: [:test])

--- a/cli-ui.gemspec
+++ b/cli-ui.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 12.3"
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency("rake", "~> 12.3")
+  spec.add_development_dependency("minitest", "~> 5.0")
 end

--- a/cli-ui.gemspec
+++ b/cli-ui.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/shopify/cli-ui"
   spec.license       = "MIT"
 
-  spec.files = `git ls-files -z`.split("\x0").reject do |f|
+  spec.files = %x(git ls-files -z).split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = "exe"

--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -155,7 +155,7 @@ module CLI
       CLI::UI::StdoutRouter.duplicate_output_to = File.open(path, 'w')
       yield
     ensure
-      if file_descriptor = CLI::UI::StdoutRouter.duplicate_output_to
+      if (file_descriptor = CLI::UI::StdoutRouter.duplicate_output_to)
         file_descriptor.close
         CLI::UI::StdoutRouter.duplicate_output_to = nil
       end

--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -77,7 +77,7 @@ module CLI
       return input if input.nil?
       formatted = CLI::UI::Formatter.new(input).format
       return formatted unless truncate_to
-      return CLI::UI::Truncater.call(formatted, truncate_to)
+      CLI::UI::Truncater.call(formatted, truncate_to)
     end
 
     # Convenience Method to format text using +CLI::UI::Formatter.format+

--- a/lib/cli/ui/color.rb
+++ b/lib/cli/ui/color.rb
@@ -35,15 +35,15 @@ module CLI
       GRAY = new('38;5;244', :grey)
 
       MAP = {
-        red:     RED,
-        green:   GREEN,
-        yellow:  YELLOW,
-        blue:    BLUE,
+        red: RED,
+        green: GREEN,
+        yellow: YELLOW,
+        blue: BLUE,
         magenta: MAGENTA,
-        cyan:    CYAN,
-        reset:   RESET,
-        bold:    BOLD,
-        gray:    GRAY,
+        cyan: CYAN,
+        reset: RESET,
+        bold: BOLD,
+        gray: GRAY,
       }.freeze
 
       class InvalidColorName < ArgumentError

--- a/lib/cli/ui/formatter.rb
+++ b/lib/cli/ui/formatter.rb
@@ -166,10 +166,10 @@ module CLI
 
       def parse_body(sc, stack = [])
         match = sc.scan(SCAN_BODY)
-        if match && match.end_with?(BEGIN_EXPR)
+        if match&.end_with?(BEGIN_EXPR)
           emit(match[DISCARD_BRACES], stack)
           parse_expr(sc, stack)
-        elsif match && match.end_with?(END_EXPR)
+        elsif match&.end_with?(END_EXPR)
           emit(match[DISCARD_BRACES], stack)
           if stack.pop == LITERAL_BRACES
             emit('}}', stack)

--- a/lib/cli/ui/formatter.rb
+++ b/lib/cli/ui/formatter.rb
@@ -12,23 +12,23 @@ module CLI
       #
       SGR_MAP = {
         # presentational
-        'red'       => '31',
-        'green'     => '32',
-        'yellow'    => '33',
+        'red' => '31',
+        'green' => '32',
+        'yellow' => '33',
         # default blue is low-contrast against black in some default terminal color scheme
-        'blue'      => '94', # 9x = high-intensity fg color x
-        'magenta'   => '35',
-        'cyan'      => '36',
-        'bold'      => '1',
-        'italic'    => '3',
+        'blue' => '94', # 9x = high-intensity fg color x
+        'magenta' => '35',
+        'cyan' => '36',
+        'bold' => '1',
+        'italic' => '3',
         'underline' => '4',
-        'reset'     => '0',
+        'reset' => '0',
 
         # semantic
-        'error'   => '31', # red
+        'error' => '31', # red
         'success' => '32', # success
         'warning' => '33', # yellow
-        'info'    => '94', # bright blue
+        'info' => '94', # bright blue
         'command' => '36', # cyan
       }.freeze
 

--- a/lib/cli/ui/frame.rb
+++ b/lib/cli/ui/frame.rb
@@ -180,7 +180,7 @@ module CLI
           items[0..-2].each do |item|
             pfx << CLI::UI.resolve_color(item).code << CLI::UI::Box::Heavy::VERT
           end
-          if item = items.last
+          if (item = items.last)
             c = Thread.current[:cliui_frame_color_override] || color || item
             pfx << CLI::UI.resolve_color(c).code \
               << CLI::UI::Box::Heavy::VERT << ' ' << CLI::UI::Color::RESET.code

--- a/lib/cli/ui/frame.rb
+++ b/lib/cli/ui/frame.rb
@@ -254,7 +254,7 @@ module CLI
           # extra-reliably, so we fall back to a less foolproof strategy. This
           # is probably better in general for cases with impoverished terminal
           # emulators and no active user.
-          if (is_ci = ![0, '', nil].include?(ENV['CI']))
+          unless [0, '', nil].include?(ENV['CI'])
             linewidth = [0, termwidth - (prefix_width + suffix_width)].max
 
             o << color.code << prefix

--- a/lib/cli/ui/progress.rb
+++ b/lib/cli/ui/progress.rb
@@ -77,11 +77,11 @@ module CLI
         filled = [(@percent_done * workable_width.to_f).ceil, 0].max
         unfilled = [workable_width - filled, 0].max
 
-        CLI::UI.resolve_text [
+        CLI::UI.resolve_text([
           FILLED_BAR + ' ' * filled,
           UNFILLED_BAR + ' ' * unfilled,
           CLI::UI::Color::RESET.code + suffix
-        ].join
+        ].join)
       end
     end
   end

--- a/lib/cli/ui/progress.rb
+++ b/lib/cli/ui/progress.rb
@@ -80,7 +80,7 @@ module CLI
         CLI::UI.resolve_text([
           FILLED_BAR + ' ' * filled,
           UNFILLED_BAR + ' ' * unfilled,
-          CLI::UI::Color::RESET.code + suffix
+          CLI::UI::Color::RESET.code + suffix,
         ].join)
       end
     end

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -36,7 +36,8 @@ module CLI
         # * +:select_ui+ - Enable long-form option selection (default: true)
         #
         # Note:
-        # * +:options+ or providing a +Block+ conflicts with +:default+ and +:is_file+, you cannot set options with either of these keywords
+        # * +:options+ or providing a +Block+ conflicts with +:default+ and +:is_file+,
+        #              you cannot set options with either of these keywords
         # * +:default+ conflicts with +:allow_empty:, you cannot set these together
         # * +:options+ conflicts with providing a +Block+ , you may only set one
         # * +:multiple+ can only be used with +:options+ or a +Block+; it is ignored, otherwise.
@@ -76,13 +77,30 @@ module CLI
         #     handler.option('python') { |selection| selection }
         #   end
         #
-        def ask(question, options: nil, default: nil, is_file: nil, allow_empty: true, multiple: false, filter_ui: true, select_ui: true, &options_proc)
+        def ask(
+          question,
+          options: nil,
+          default: nil,
+          is_file: nil,
+          allow_empty: true,
+          multiple: false,
+          filter_ui: true,
+          select_ui: true,
+          &options_proc
+        )
           if (options || block_given?) && (default || is_file)
             raise(ArgumentError, 'conflicting arguments: options provided with default or is_file')
           end
 
           if options || block_given?
-            ask_interactive(question, options, multiple: multiple, filter_ui: filter_ui, select_ui: select_ui, &options_proc)
+            ask_interactive(
+              question,
+              options,
+              multiple: multiple,
+              filter_ui: filter_ui,
+              select_ui: select_ui,
+              &options_proc
+            )
           else
             ask_free_form(question, default, is_file, allow_empty)
           end
@@ -132,7 +150,9 @@ module CLI
         private
 
         def ask_free_form(question, default, is_file, allow_empty)
-          raise(ArgumentError, 'conflicting arguments: default enabled but allow_empty is false') if default && !allow_empty
+          if default && !allow_empty
+            raise(ArgumentError, 'conflicting arguments: default enabled but allow_empty is false')
+          end
 
           if default
             puts_question("#{question} (empty = #{default})")

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -167,7 +167,7 @@ module CLI
           raise(ArgumentError, 'insufficient options') if options.nil? || options.empty?
           instructions = (multiple ? "Toggle options. " : "") + "Choose with ↑ ↓ ⏎"
           instructions += ", filter with 'f'" if filter_ui
-          instructions += ", enter option with 'e'" if select_ui and options.size > 9
+          instructions += ", enter option with 'e'" if select_ui && (options.size > 9)
           puts_question("#{question} {{yellow:(#{instructions})}}")
           resp = interactive_prompt(options, multiple: multiple)
 

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -77,7 +77,7 @@ module CLI
         #   end
         #
         def ask(question, options: nil, default: nil, is_file: nil, allow_empty: true, multiple: false, filter_ui: true, select_ui: true, &options_proc)
-          if ((options || block_given?) && (default || is_file))
+          if (options || block_given?) && (default || is_file)
             raise(ArgumentError, 'conflicting arguments: options provided with default or is_file')
           end
 
@@ -132,7 +132,7 @@ module CLI
         private
 
         def ask_free_form(question, default, is_file, allow_empty)
-          raise(ArgumentError, 'conflicting arguments: default enabled but allow_empty is false') if (default && !allow_empty)
+          raise(ArgumentError, 'conflicting arguments: default enabled but allow_empty is false') if default && !allow_empty
 
           if default
             puts_question("#{question} (empty = #{default})")

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -442,12 +442,12 @@ module CLI
             format = "{{cyan:#{format}}}" if @multiple && is_chosen && num != @active
             format = " #{format}"
 
-            message += sprintf(format, CHECKBOX_ICON[is_chosen]) if @multiple && num && num > 0
+            message += format(format, CHECKBOX_ICON[is_chosen]) if @multiple && num && num > 0
             message += format_choice(format, choice)
 
             if num == @active
 
-              color = (filtering? || selecting?) ? 'green' : 'blue'
+              color = filtering? || selecting? ? 'green' : 'blue'
               message = message.split("\n").map { |l| "{{#{color}:> #{l.strip}}}" }.join("\n")
             end
 
@@ -463,7 +463,7 @@ module CLI
 
           return eol if lines.empty? # Handle blank options
 
-          lines.map! { |l| sprintf(format, l) + eol }
+          lines.map! { |l| format(format, l) + eol }
           lines.join("\n")
         end
       end

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -128,7 +128,7 @@ module CLI
         # Don't use this in place of +@displaying_metadata+, this updates too
         # quickly to be useful when drawing to the screen.
         def display_metadata?
-          filtering? or selecting? or has_filter?
+          filtering? || selecting? || has_filter?
         end
 
         def num_lines
@@ -136,7 +136,7 @@ module CLI
 
           option_length = presented_options.reduce(0) do |total_length, (_, option_number)|
             # Handle continuation markers and "Done" option when multiple is true
-            next total_length + 1 if option_number.nil? or option_number.zero?
+            next total_length + 1 if option_number.nil? || option_number.zero?
             total_length + @option_lengths[option_number - 1]
           end
 
@@ -216,7 +216,7 @@ module CLI
           @redraw = true
 
           # Control+D or Backspace on empty search closes search
-          if char == CTRL_D or (@filter.empty? and char == BACKSPACE)
+          if (char == CTRL_D) || (@filter.empty? && (char == BACKSPACE))
             @filter = ''
             @state = :root
             return
@@ -418,7 +418,7 @@ module CLI
                             select_text = @active
                             select_text = '{{info:e, q, or up/down anytime to exit}}' if @active == 0
                             "Select: #{select_text}"
-                          elsif filtering? or has_filter?
+                          elsif filtering? || has_filter?
                             filter_text = @filter
                             filter_text = '{{info:Ctrl-D anytime or Backspace now to exit}}' if @filter.empty?
                             "Filter: #{filter_text}"
@@ -447,7 +447,7 @@ module CLI
 
             if num == @active
 
-              color = (filtering? or selecting?) ? 'green' : 'blue'
+              color = (filtering? || selecting?) ? 'green' : 'blue'
               message = message.split("\n").map { |l| "{{#{color}:> #{l.strip}}}" }.join("\n")
             end
 

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -240,7 +240,7 @@ module CLI
           wait_for_user_input until @redraw
         end
 
-        # rubocop:disable Style/WhenThen,Layout/SpaceBeforeSemicolon
+        # rubocop:disable Style/WhenThen,Layout/SpaceBeforeSemicolon,Style/Semicolon
         def wait_for_user_input
           char = read_char
           @last_char = char
@@ -422,7 +422,7 @@ module CLI
             filter_text = @filter
             filter_text = '{{info:Ctrl-D anytime or Backspace now to exit}}' if @filter.empty?
             "Filter: #{filter_text}"
-                          end
+          end
 
           if metadata_text
             CLI::UI.with_frame_color(:blue) do

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -153,7 +153,7 @@ module CLI
         CTRL_D = "\u0004"
 
         def up
-          active_index = @filtered_options.index { |_,num| num == @active } || 0
+          active_index = @filtered_options.index { |_, num| num == @active } || 0
 
           previous_visible = @filtered_options[active_index - 1]
           previous_visible ||= @filtered_options.last
@@ -163,7 +163,7 @@ module CLI
         end
 
         def down
-          active_index = @filtered_options.index { |_,num| num == @active } || 0
+          active_index = @filtered_options.index { |_, num| num == @active } || 0
 
           next_visible = @filtered_options[active_index + 1]
           next_visible ||= @filtered_options.first
@@ -231,7 +231,7 @@ module CLI
 
         def select_current
           # Prevent selection of invisible options
-          return unless presented_options.any? { |_,num| num == @active }
+          return unless presented_options.any? { |_, num| num == @active }
           select_n(@active)
         end
 
@@ -273,7 +273,7 @@ module CLI
             when ESC             ; @state = :esc
             when 'k'             ; up   ; @state = :root
             when 'j'             ; down ; @state = :root
-            when 'e',':','G','q' ; stop_line_select
+            when 'e', ':', 'G', 'q' ; stop_line_select
             when '0'..'9'        ; build_selection(char)
             when BACKSPACE       ; chop_selection  # Pop last input on backspace
             when ' ', "\r", "\n" ; select_current
@@ -347,7 +347,7 @@ module CLI
 
           @presented_options = @options.zip(1..Float::INFINITY)
           if has_filter?
-            @presented_options.select! { |option,_| option.downcase.include?(@filter.downcase) }
+            @presented_options.select! { |option, _| option.downcase.include?(@filter.downcase) }
           end
 
           # Used for selection purposes
@@ -388,7 +388,7 @@ module CLI
         end
 
         def index_of_active_option
-          @presented_options.index { |_,num| num == @active }.to_i
+          @presented_options.index { |_, num| num == @active }.to_i
         end
 
         def ensure_last_item_is_continuation_marker

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -95,16 +95,16 @@ module CLI
           @option_lengths = @options.map do |text|
             width = 1 if text.empty?
             width ||= text
-                        .split("\n")
-                        .reject(&:empty?)
-                        .map { |l| (CLI::UI.fmt(l, enable_color: false).length / max_width).ceil }
-                        .reduce(&:+)
+              .split("\n")
+              .reject(&:empty?)
+              .map { |l| (CLI::UI.fmt(l, enable_color: false).length / max_width).ceil }
+              .reduce(&:+)
 
             width
           end
         end
 
-        def reset_position(number_of_lines=num_lines)
+        def reset_position(number_of_lines = num_lines)
           # This will put us back at the beginning of the options
           # When we redraw the options, they will be overwritten
           CLI::UI.raw do
@@ -112,7 +112,7 @@ module CLI
           end
         end
 
-        def clear_output(number_of_lines=num_lines)
+        def clear_output(number_of_lines = num_lines)
           CLI::UI.raw do
             # Write over all lines with whitespace
             number_of_lines.times { puts(' ' * CLI::UI::Terminal.width) }
@@ -260,7 +260,7 @@ module CLI
             when 'f', '/'                  ; start_filter
             when ('0'..@options.size.to_s) ; select_n(char.to_i)
             when 'y', 'n'                  ; select_bool(char)
-            when " ", "\r", "\n"           ; select_current  # <enter>
+            when " ", "\r", "\n"           ; select_current # <enter>
             end
           when :filter
             case char
@@ -275,7 +275,7 @@ module CLI
             when 'j'             ; down ; @state = :root
             when 'e', ':', 'G', 'q' ; stop_line_select
             when '0'..'9'        ; build_selection(char)
-            when BACKSPACE       ; chop_selection  # Pop last input on backspace
+            when BACKSPACE       ; chop_selection # Pop last input on backspace
             when ' ', "\r", "\n" ; select_current
             end
           when :esc
@@ -415,13 +415,13 @@ module CLI
           max_num_length = (@options.size + 1).to_s.length
 
           metadata_text = if selecting?
-                            select_text = @active
-                            select_text = '{{info:e, q, or up/down anytime to exit}}' if @active == 0
-                            "Select: #{select_text}"
-                          elsif filtering? || has_filter?
-                            filter_text = @filter
-                            filter_text = '{{info:Ctrl-D anytime or Backspace now to exit}}' if @filter.empty?
-                            "Filter: #{filter_text}"
+            select_text = @active
+            select_text = '{{info:e, q, or up/down anytime to exit}}' if @active == 0
+            "Select: #{select_text}"
+          elsif filtering? || has_filter?
+            filter_text = @filter
+            filter_text = '{{info:Ctrl-D anytime or Backspace now to exit}}' if @filter.empty?
+            "Filter: #{filter_text}"
                           end
 
           if metadata_text

--- a/lib/cli/ui/spinner/spin_group.rb
+++ b/lib/cli/ui/spinner/spin_group.rb
@@ -52,7 +52,7 @@ module CLI
             end
 
             @force_full_render = false
-            @done      = false
+            @done = false
             @exception = nil
             @success   = false
           end
@@ -197,7 +197,7 @@ module CLI
                     @consumed_lines += 1
                   else
                     offset = @consumed_lines - int_index
-                    move_to   = CLI::UI::ANSI.cursor_up(offset) + "\r"
+                    move_to = CLI::UI::ANSI.cursor_up(offset) + "\r"
                     move_from = "\r" + CLI::UI::ANSI.cursor_down(offset)
 
                     print(move_to + task.render(idx, idx.zero?, width: width) + move_from)

--- a/lib/cli/ui/stdout_router.rb
+++ b/lib/cli/ui/stdout_router.rb
@@ -159,7 +159,7 @@ module CLI
           id = format("%05d", rand(10**5))
           Thread.current[:cliui_output_id] = {
             id: id,
-            streams: on_streams
+            streams: on_streams,
           }
           yield(id)
         ensure

--- a/lib/cli/ui/stdout_router.rb
+++ b/lib/cli/ui/stdout_router.rb
@@ -30,7 +30,7 @@ module CLI
           # hook return of false suppresses output.
           if !hook || hook.call(args.first, @name) != false
             @stream.write_without_cli_ui(*prepend_id(@stream, args))
-            if dup = StdoutRouter.duplicate_output_to
+            if (dup = StdoutRouter.duplicate_output_to)
               dup.write(*prepend_id(dup, args))
             end
           end

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -11,7 +11,7 @@ module CLI
       # Otherwise will return 80
       #
       def self.width
-        if console = IO.respond_to?(:console) && IO.console
+        if (console = IO.respond_to?(:console) && IO.console)
           width = console.winsize[1]
           width.zero? ? DEFAULT_WIDTH : width
         else
@@ -22,7 +22,7 @@ module CLI
       end
 
       def self.height
-        if console = IO.respond_to?(:console) && IO.console
+        if (console = IO.respond_to?(:console) && IO.console)
           height = console.winsize[0]
           height.zero? ? DEFAULT_HEIGHT : height
         else

--- a/lib/cli/ui/truncater.rb
+++ b/lib/cli/ui/truncater.rb
@@ -52,11 +52,11 @@ module CLI
                 end
               end
             when PARSE_ESC
-              case cp
+              mode = case cp
               when LEFT_SQUARE_BRACKET
-                mode = PARSE_ANSI
+                PARSE_ANSI
               else
-                mode = PARSE_ROOT
+                PARSE_ROOT
               end
             when PARSE_ANSI
               # ANSI escape codes preeeetty much have the format of:

--- a/test/cli/ui/color_test.rb
+++ b/test/cli/ui/color_test.rb
@@ -28,8 +28,8 @@ module CLI
       def test_useful_exception
         e = begin
           Color.lookup(:foobar)
-        rescue => e
-          e
+            rescue => e
+              e
         end
         assert_match(/invalid color: :foobar/, e.message) # error
         assert_match(/Color\.available/, e.message) # where to find colors

--- a/test/cli/ui/glyph_test.rb
+++ b/test/cli/ui/glyph_test.rb
@@ -28,8 +28,8 @@ module CLI
       def test_useful_exception
         e = begin
           Glyph.lookup('$')
-        rescue => e
-          e
+            rescue => e
+              e
         end
         assert_match(/invalid glyph handle: \$/, e.message) # error
         assert_match(/Glyph\.available/, e.message) # where to find colors

--- a/test/cli/ui/printer_test.rb
+++ b/test/cli/ui/printer_test.rb
@@ -47,7 +47,7 @@ module CLI
       end
 
       def test_puts_pipe_closed
-        IO.pipe do |r, w|
+        IO.pipe do |_r, w|
           w.close
           assert_raises(IOError) do
             Printer.puts('foo', to: w, graceful: false)

--- a/test/cli/ui/prompt/options_handler_test.rb
+++ b/test/cli/ui/prompt/options_handler_test.rb
@@ -24,7 +24,7 @@ module CLI
         def test_call
           handler = OptionsHandler.new
           procedure_called = false
-          procedure = Proc.new do |selection|
+          procedure = proc do |selection|
             procedure_called = true
             selection
           end

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -319,7 +319,7 @@ module CLI
       end
 
       def test_ask_interactive_with_blank_option
-        _run('j','j',' ') do
+        _run('j', 'j', ' ') do
           Prompt.ask('q') do |h|
             h.option('a') { |a| 'a was selected' }
             h.option('') { |b| 'b was selected' }

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -213,7 +213,7 @@ module CLI
         assert_equal 'insufficient options', exception.message
 
         exception = assert_raises(ArgumentError) do
-          Prompt.ask('q') { |h| {} }
+          Prompt.ask('q') { |_h| {} }
         end
         assert_equal 'insufficient options', exception.message
       end
@@ -221,7 +221,7 @@ module CLI
       def test_ask_interactive_with_block
         _run('1') do
           Prompt.ask('q') do |h|
-            h.option('a') { |a| 'a was selected' }
+            h.option('a') { |_a| 'a was selected' }
           end
         end
         expected_out = strip_heredoc(<<-EOF)
@@ -321,8 +321,8 @@ module CLI
       def test_ask_interactive_with_blank_option
         _run('j', 'j', ' ') do
           Prompt.ask('q') do |h|
-            h.option('a') { |a| 'a was selected' }
-            h.option('') { |b| 'b was selected' }
+            h.option('a') { |_a| 'a was selected' }
+            h.option('') { |_b| 'b was selected' }
           end
         end
         blank = ''

--- a/test/cli/ui/spinner_test.rb
+++ b/test/cli/ui/spinner_test.rb
@@ -46,9 +46,9 @@ module CLI
             assert task
             assert_respond_to task, :update_title
             sleep CLI::UI::Spinner::PERIOD * 2.5
-            task.update_title '今日'
+            task.update_title('今日')
             sleep CLI::UI::Spinner::PERIOD * 2.5
-            task.update_title '疲れたんだ'
+            task.update_title('疲れたんだ')
             sleep CLI::UI::Spinner::PERIOD * 2.5
           end
         end

--- a/test/cli/ui/stdout_router_test.rb
+++ b/test/cli/ui/stdout_router_test.rb
@@ -11,7 +11,7 @@ module CLI
             end
           end
         end
-        assert_match /\[\d{5}\] hello/, out
+        assert_match(/\[\d{5}\] hello/, out)
       end
 
       def test_with_id_with_argument_errors

--- a/test/cli/ui/terminal_test.rb
+++ b/test/cli/ui/terminal_test.rb
@@ -4,7 +4,7 @@ module CLI
   module UI
     class TerminalTest < MiniTest::Test
       def test_width
-        skip 'flaky'
+        skip('flaky')
 
         obj = Object.new
         class << obj

--- a/test/cli/ui/truncater_test.rb
+++ b/test/cli/ui/truncater_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 module CLI
   module UI
     class TruncaterTest < MiniTest::Test
-
       MAN     = "\u{1f468}" # width=2
       COOKING = "\u{1f373}" # width=2
       ZWJ     = "\u{200d}"  # width=complicated
@@ -25,7 +24,7 @@ module CLI
 
       def assert_example(width, from, to)
         truncated = CLI::UI::Truncater.call(from, width)
-        assert_equal(to.codepoints.map{|c|c.to_s(16)}, truncated.codepoints.map{|c|c.to_s(16)})
+        assert_equal(to.codepoints.map { |c| c.to_s(16) }, truncated.codepoints.map { |c| c.to_s(16) })
       end
     end
   end


### PR DESCRIPTION
The linter hasn't been run for a while, the CI wasn't enforcing it.

- Import rubocop configs from cli-kit (sister project)
- Commit Gemfile.lock, like on cli-kit
- Change target version of rubocop to 2.3
- Change bundler version in travis config to match the gemfile.lock

It's worth noting that the 2.1 parser isn't supported after rubocop
0.58 _and_ that it wasn't even passing because this project uses `<<~`, which isn't valid 2.1
syntax. `dev.yml` is also configured to use ruby 2.3