### PR TITLE
Update CI dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ sudo: false
 language: ruby
 rvm:
   - 2.4.6
-before_install: gem install bundler -v 1.17.3
+before_install: gem install bundler -v '~> 2.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
   - 2.3.3
   - 2.4.6
   - 2.5.1
-before_install: gem install bundler -v '~> 2.0'
+before_install: gem update --system --no-document && gem install bundler -v '~> 2.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ language: ruby
 rvm:
   - 2.3.3
   - 2.4.6
+  - 2.5.1
 before_install: gem install bundler -v '~> 2.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: ruby
 rvm:
+  - 2.3.3
   - 2.4.6
 before_install: gem install bundler -v '~> 2.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.3
+  - 2.4.6
 before_install: gem install bundler -v 1.17.3

--- a/lib/cli/ui/stdout_router.rb
+++ b/lib/cli/ui/stdout_router.rb
@@ -117,6 +117,10 @@ module CLI
           prev_frame_inset = Thread.current[:no_cliui_frame_inset]
           prev_hook = Thread.current[:cliui_output_hook]
 
+          if Thread.current.respond_to?(:report_on_exception)
+            Thread.current.report_on_exception = false
+          end
+
           self.class.with_stdin_masked do
             Thread.current[:no_cliui_frame_inset] = !@with_frame_inset
             Thread.current[:cliui_output_hook] = ->(data, stream) do


### PR DESCRIPTION
Ruby version 2.3 is no longer officially supported so I think it's probably a good idea to bump the version tested to 2.4 - which is still supported.

Additionally, newer versions of bundler support automatic use of older versions when detected in the Gemfile.lock.  So, it should be safe to install the latest version of bundler even if the lockfile specifies an older version.