### PR TITLE
IO#write(string, ...), not IO#write(string):

### DIFF
--- a/lib/cli/ui/stdout_router.rb
+++ b/lib/cli/ui/stdout_router.rb
@@ -26,13 +26,14 @@ module CLI
             end
           end
 
-          hook = Thread.current[:cliui_output_hook]
           # hook return of false suppresses output.
-          if !hook || hook.call(args.first, @name) != false
-            @stream.write_without_cli_ui(*prepend_id(@stream, args))
-            if (dup = StdoutRouter.duplicate_output_to)
-              dup.write(*prepend_id(dup, args))
-            end
+          if (hook = Thread.current[:cliui_output_hook])
+            return if hook.call(args.map(&:to_s).join, @name) == false
+          end
+
+          @stream.write_without_cli_ui(*prepend_id(@stream, args))
+          if (dup = StdoutRouter.duplicate_output_to)
+            dup.write(*prepend_id(dup, args))
           end
         end
 


### PR DESCRIPTION
Here's the doc:

    Writes the given strings to ios. The stream must be opened for
    writing.  Arguments that are not a string will be converted to a
    string using to_s. Returns the number of bytes written in total.

So we're currently only passing the first arg, if multiple, to the hook.

I refactored while I'm at it here, the only actual change is replacing `hook.call(args.first, ...` with `hook.call(args.map(&:to_s).join, ...`