### PR TITLE
Add a delay parameter to spinner

### DIFF
--- a/lib/cli/ui/spinner.rb
+++ b/lib/cli/ui/spinner.rb
@@ -58,8 +58,8 @@ module CLI
       #
       #   CLI::UI::Spinner.spin('Title') { sleep 1.0 }
       #
-      def self.spin(title, auto_debrief: true, &block)
-        sg = SpinGroup.new(auto_debrief: auto_debrief)
+      def self.spin(title, auto_debrief: true, delay: nil, &block)
+        sg = SpinGroup.new(auto_debrief: auto_debrief, delay: delay)
         sg.add(title, &block)
         sg.wait
       end

--- a/test/cli/ui/spinner_test.rb
+++ b/test/cli/ui/spinner_test.rb
@@ -21,6 +21,35 @@ module CLI
         )
       end
 
+      def test_spinner_delay_no_show
+        out, err = capture_io do
+          CLI::UI::StdoutRouter.ensure_activated
+          CLI::UI::Spinner.spin('sleeping', delay: CLI::UI::Spinner::PERIOD * 2.5) do
+            sleep CLI::UI::Spinner::PERIOD
+          end
+        end
+
+        assert_equal('', err)
+        assert_equal('', out)
+      end
+
+      def test_spinner_delay_show
+        out, err = capture_io do
+          CLI::UI::StdoutRouter.ensure_activated
+          CLI::UI::Spinner.spin('sleeping', delay: CLI::UI::Spinner::PERIOD) do
+            sleep CLI::UI::Spinner::PERIOD * 2.5
+          end
+        end
+
+        assert_equal('', err)
+        match_lines(
+          out,
+          /⠙ sleeping/, # Skips the first glyph
+          /⠹/,
+          /✓/
+        )
+      end
+
       def test_async
         out, err = capture_io do
           CLI::UI::StdoutRouter.ensure_activated


### PR DESCRIPTION
If specified, the SpinGroup will not print anything until it has been
running for at least that duration.

⚠️ Not implemented:
If the task fails _before_ it has started printing the spinners,
it will debrief as usual, but without printing the failed spinner.
The task title is included in the debrief, so it doesn't seem like a big deal.

🎩 
```
irb(main):001:0> CLI::UI::StdoutRouter.enable

# Delay > sleep: no print
irb(main):002:0> CLI::UI::Spinner.spin('foo', delay: 1.1) { sleep(1.0); puts('stdout'); $stderr.puts('stderr') }
=> true

# Delay < sleep: print
irb(main):003:0> CLI::UI::Spinner.spin('foo', delay: 0.5) { sleep(1.0); puts('stdout'); $stderr.puts('stderr') }
✓ foo
=> true

# Delay > sleep: print, error
# NOTICE: No "✗ foo"
irb(main):003:0> CLI::UI::Spinner.spin('foo', delay: 1.1) { sleep(1.0); puts('stdout'); $stderr.puts('stderr'); raise }
┏━━ Task Failed: foo ━━━
┃ RuntimeError:
...
┣━━ STDOUT ━━
┃ stdout
┣━━ STDERR ━━
┃ stderr
┗━━━━━━━━

# Delay < sleep: print, error
irb(main):003:0> CLI::UI::Spinner.spin('foo', delay: 0.5) { sleep(1.0); puts('stdout'); $stderr.puts('stderr'); raise }
✗ foo
┏━━ Task Failed: foo ━━━
┃ RuntimeError:
...
┣━━ STDOUT ━━
┃ stdout
┣━━ STDERR ━━
┃ stderr
┗━━━━━━━━


# Delay, then print ✓ + spinner, then finish
irb(main):002:0> sg = CLI::UI::Spinner::SpinGroup.new(delay: 1.0); sg.add('foo') { sleep(0.5) }; sg.add('bar') { sleep(1.5) }; sg.wait
✓ foo
✓ bar
=> true

# Delay + instant raise
# NOTICE: No "✗ foo"
irb(main):002:0> CLI::UI::Spinner.spin('foo', delay: 0.5, auto_debrief: false) { raise }
=> false

# Without delay + raise
irb(main):003:0> CLI::UI::Spinner.spin('foo', auto_debrief: false) { raise }
✗ foo
=> false
```

Requires https://github.com/Shopify/cli-ui/pull/99