### PR TITLE
multi-select DONE is selectable and at end of menu

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -351,9 +351,8 @@ module CLI
           end
 
           # Used for selection purposes
+          @presented_options.push([DONE, 0]) if @multiple
           @filtered_options = @presented_options.dup
-
-          @presented_options.unshift([DONE, 0]) if @multiple
 
           ensure_visible_is_active if has_filter?
 
@@ -431,7 +430,7 @@ module CLI
           end
 
           options.each do |choice, num|
-            is_chosen = @multiple && num && @chosen[num - 1]
+            is_chosen = @multiple && num && @chosen[num - 1] && num != 0
 
             padding = ' ' * (max_num_length - num.to_s.length)
             message = "  #{num}#{num ? '.' : ' '}#{padding}"


### PR DESCRIPTION
Closes https://github.com/Shopify/production-excellence/issues/57

### Goals
Part of the `dev runtime` UI relies on multi-select menus. Our experience so far with the multi-select menu in cli-ui has prompted us to propose a change:
- Make the `Done` option selectable via cursor
- Move the `Done` option to the bottom (but keep its option number as `0`)

### Examples

Before this change:
<img width="1207" alt="Screen Shot 2020-03-16 at 10 01 38 AM" src="https://user-images.githubusercontent.com/31742287/76765730-41210280-676d-11ea-9aa4-b0eefe026be2.png">

After this change:
<img width="1571" alt="Screen Shot 2020-03-16 at 9 59 41 AM" src="https://user-images.githubusercontent.com/31742287/76765519-e9829700-676c-11ea-99dd-824b622166b1.png">

### Discussion

- Currently, we don't pin the `0. Done` option so that it's always visible (in the case of a very long list of options that extend past the screen). Since this seems unlikely, and wasn't implemented for when `Done` is at the top, I haven't done so, here.

- There's no helpful prompt (e.g. `press '0' when Done`). One could argue that the fact that `0. Done` has no checkmark should be a good enough indicator of what it will do, but I'm open to suggestions.

cc @Shopify/production-excellence 