### PR TITLE
Upgrades to ruby@2.5.1

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,5 +1,5 @@
 up:
-  - ruby: 2.3.3
+  - ruby: 2.5.1
   - bundler
 
 commands:


### PR DESCRIPTION
I needed to poke around in this gem and had `openssl` problems when doing `dev up`. Ruby 2.3.3 is pretty old. Originally, I used 2.7.0, like in `cli-kit`, but that caused test failures. So... I used the latest version in `.travis.yml` (2.5.1).