### PR TITLE
Fix a bug under ruby 2.7

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -250,17 +250,18 @@ module CLI
           when CTRL_C   ; raise Interrupt
           end
 
+          max_digit = [@options.size, 9].min.to_s
           case @state
           when :root
             case char
-            when ESC                       ; @state = :esc
-            when 'k'                       ; up
-            when 'j'                       ; down
-            when 'e', ':', 'G'             ; start_line_select
-            when 'f', '/'                  ; start_filter
-            when ('0'..@options.size.to_s) ; select_n(char.to_i)
-            when 'y', 'n'                  ; select_bool(char)
-            when " ", "\r", "\n"           ; select_current # <enter>
+            when ESC              ; @state = :esc
+            when 'k'              ; up
+            when 'j'              ; down
+            when 'e', ':', 'G'    ; start_line_select
+            when 'f', '/'         ; start_filter
+            when ('0'..max_digit) ; select_n(char.to_i)
+            when 'y', 'n'         ; select_bool(char)
+            when " ", "\r", "\n"  ; select_current # <enter>
             end
           when :filter
             case char


### PR DESCRIPTION
Ruby 2.7 changed case equality for string ranges. We're comparing to a character here, so we should have maxed out at 9 anyway.
```
$ /opt/rubies/2.6.5/bin/ruby -e 'puts ("0".."10") === "2"'
true
$ /opt/rubies/2.7.1/bin/ruby -e 'puts ("0".."10") === "2"'
false
```