### PR TITLE
Allow setting defaults for `CLI::UI::Prompt.ask(multiple: true)`

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -22,8 +22,8 @@ module CLI
         # Ask an interactive question
         #   CLI::UI::Prompt::InteractiveOptions.call(%w(rails go python))
         #
-        def self.call(options, multiple: false)
-          list = new(options, multiple: multiple)
+        def self.call(options, multiple: false, default: nil)
+          list = new(options, multiple: multiple, default: default)
           selected = list.call
           if multiple
             selected.map { |s| options[s - 1] }
@@ -39,7 +39,7 @@ module CLI
         #
         #   CLI::UI::Prompt::InteractiveOptions.new(%w(rails go python))
         #
-        def initialize(options, multiple: false)
+        def initialize(options, multiple: false, default: nil)
           @options = options
           @active = 1
           @marker = '>'
@@ -52,7 +52,13 @@ module CLI
           @filter = ''
           # 0-indexed array representing if selected
           # @options[0] is selected if @chosen[0]
-          @chosen = Array.new(@options.size) { false } if multiple
+          if multiple
+            @chosen = if default
+              @options.map { |option| default.include?(option) }
+            else
+              Array.new(@options.size) { false }
+            end
+          end
           @redraw = true
           @presented_options = []
         end

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -199,6 +199,11 @@ module CLI
           Prompt.ask('q', options: %w(a b)) { |h| h.option('a') }
         end
         assert_equal('conflicting arguments: options and block given', error.message)
+
+        error = assert_raises(ArgumentError) do
+          Prompt.ask('q', options: %w(a b), multiple: true, default: %w(b c)) { |h| h.option('a') }
+        end
+        assert_equal('conflicting arguments: default should only include elements present in options', error.message)
       end
 
       def test_ask_interactive_insufficient_options
@@ -447,6 +452,14 @@ module CLI
         end
 
         assert_result(nil, nil, ['1', '3', '5'])
+      end
+
+      def test_ask_multiple_with_default_values
+        _run('1', '0') do
+          Prompt.ask('q', options: ('1'..'10').to_a, multiple: true, default: %w(2 3))
+        end
+
+        assert_result(nil, nil, ['1', '2', '3'])
       end
 
       private


### PR DESCRIPTION
We want to be able to provide pre-selected values when asking with `multiple: true`. I went with a new argument because of this:

https://github.com/Shopify/cli-ui/blob/61c55842c54cda43dc7522881c26dc606c5fdfcb/lib/cli/ui/prompt.rb#L91-L93

Would it be better to use `:default` and avoid raising on that line if `:multiple == true`? What's the rationale behind that check?