### PR TITLE
Improve Performance of Interactive Options Over Large Lists

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -363,6 +363,18 @@ module CLI
 
           ensure_visible_is_active if has_filter?
 
+          # Must have more lines before the selection than we can display
+          if distance_from_start_to_selection > max_lines
+            @presented_options.shift(distance_from_start_to_selection - max_lines)
+            ensure_first_item_is_continuation_marker
+          end
+
+          # Must have more lines after the selection than we can display
+          if distance_from_selection_to_end > max_lines
+            @presented_options.pop(distance_from_selection_to_end - max_lines)
+            ensure_last_item_is_continuation_marker
+          end
+
           while num_lines > max_lines
             # try to keep the selection centered in the window:
             if distance_from_selection_to_end > distance_from_start_to_selection


### PR DESCRIPTION
Drastically reduces the number of iterations needed to determine displayed options by trimming the list down to, at most, `max_length * 2` items.

On my machine, this speeds up list rendering to the point that the render loop spends most of its time waiting for user input.