### PR TITLE
Move "Done" Option in Multi-select to Top Instead of Bottom

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -358,7 +358,7 @@ module CLI
           end
 
           # Used for selection purposes
-          @presented_options.push([DONE, 0]) if @multiple
+          @presented_options.unshift([DONE, 0]) if @multiple
           @filtered_options = @presented_options.dup
 
           ensure_visible_is_active if has_filter?


### PR DESCRIPTION
Happened to notice this while working on the other PR.  Given the number of this option, it seems like it should be at the top, instead of the bottom.