### PR TITLE
Fix deprectaion warning: kwargs

### DIFF
--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -131,8 +131,8 @@ module CLI
     # * +args+ - arguments for +Frame.open+
     # * +block+ - block for +Frame.open+
     #
-    def self.frame(*args, &block)
-      CLI::UI::Frame.open(*args, &block)
+    def self.frame(*args, **kwargs, &block)
+      CLI::UI::Frame.open(*args, **kwargs, &block)
     end
 
     # Convenience Method for +CLI::UI::Spinner.spin+
@@ -142,8 +142,8 @@ module CLI
     # * +args+ - arguments for +Spinner.open+
     # * +block+ - block for +Spinner.open+
     #
-    def self.spinner(*args, &block)
-      CLI::UI::Spinner.spin(*args, &block)
+    def self.spinner(*args, **kwargs, &block)
+      CLI::UI::Spinner.spin(*args, **kwargs, &block)
     end
 
     # Convenience Method to override frame color using +CLI::UI::Frame.with_frame_color+


### PR DESCRIPTION
Warning was:

```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```