### PR TITLE
Fix progress bar in a frame

### DIFF
--- a/lib/cli/ui/progress.rb
+++ b/lib/cli/ui/progress.rb
@@ -75,7 +75,7 @@ module CLI
       #
       def to_s
         suffix = " #{(@percent_done * 100).floor}%".ljust(5)
-        workable_width = @max_width - Frame.prefix_width - suffix.size
+        workable_width = @max_width - Frame.prefix_width - suffix.size - 1
         filled = [(@percent_done * workable_width.to_f).ceil, 0].max
         unfilled = [workable_width - filled, 0].max
 


### PR DESCRIPTION
A progress bar in a frame will print ticks on new lines rather than
overwritting the existing line. This was due to the fact that
Frame.prefix_width was updated to no longer included the trailing space
after the prefix, forcing the cursor to wrap onto the next line.

See https://github.com/Shopify/dev/pull/5137