### PR TITLE
Fix prefix_width not accounting for final space; Fix frame_style/bracket

### DIFF
--- a/lib/cli/ui/frame.rb
+++ b/lib/cli/ui/frame.rb
@@ -227,11 +227,12 @@ module CLI
         end
 
         # The width of a prefix given the number of Frames in the stack
-        # Does _not_ account for the space at the end of the final prefix
         def prefix_width
-          FrameStack.items.reduce(0) do |width, item|
+          w = FrameStack.items.reduce(0) do |width, item|
             width + item.frame_style.prefix_width
           end
+
+          w.zero? ? w : w + 1
         end
 
         # Override a color for a given thread.

--- a/lib/cli/ui/frame/frame_style/box.rb
+++ b/lib/cli/ui/frame/frame_style/box.rb
@@ -20,10 +20,6 @@ module CLI
               VERTICAL
             end
 
-            def prefix_width
-              CLI::UI::ANSI.printing_width(prefix)
-            end
-
             # Draws the "Open" line for this frame style
             #
             # ==== Attributes

--- a/lib/cli/ui/frame/frame_style/box.rb
+++ b/lib/cli/ui/frame/frame_style/box.rb
@@ -99,6 +99,9 @@ module CLI
 
               preamble_width = CLI::UI::ANSI.printing_width(preamble)
               preamble_start = Frame.prefix_width
+              # If prefix_width is non-zero, we need to subtract the width of
+              # the final space, since we're going to write over it.
+              preamble_start -= 1 unless preamble_start.zero?
               preamble_end   = preamble_start + preamble_width
 
               suffix_width = CLI::UI::ANSI.printing_width(suffix)

--- a/lib/cli/ui/frame/frame_style/box.rb
+++ b/lib/cli/ui/frame/frame_style/box.rb
@@ -102,7 +102,7 @@ module CLI
               # If prefix_width is non-zero, we need to subtract the width of
               # the final space, since we're going to write over it.
               preamble_start -= 1 unless preamble_start.zero?
-              preamble_end   = preamble_start + preamble_width
+              preamble_end = preamble_start + preamble_width
 
               suffix_width = CLI::UI::ANSI.printing_width(suffix)
               suffix_end   = termwidth - 2


### PR DESCRIPTION
While I was fixing the issue from #143, I noticed that bracket style printing had also been broken by the switch back to having Frame print the final space.  This PR fixes both.

Fixing the bracket frame style required printing it similarly to the box style (using `print_at_x`) instead of the more naive way I'd originally written.

I've been trying to figure out if there are any tests that we could potentially add to surface these kinds of issues, but, based on some comments about the CI server and the lack of existing Frame tests, I assume that such a thing is difficult to impossible to automatically test.  Perhaps a simple printout of some common frame situations and a progress bar (both in and out of a frame) as a sort of visual check that can be performed when running tests?