### PR TITLE
Revert "Revert "Fix UI issues on Windows""

### DIFF
--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -4,6 +4,7 @@ module CLI
     autoload :Glyph,              'cli/ui/glyph'
     autoload :Color,              'cli/ui/color'
     autoload :Frame,              'cli/ui/frame'
+    autoload :OS,                 'cli/ui/os'
     autoload :Printer,            'cli/ui/printer'
     autoload :Progress,           'cli/ui/progress'
     autoload :Prompt,             'cli/ui/prompt'

--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -106,7 +106,9 @@ module CLI
       # * +n+ - The column to move to
       #
       def self.cursor_horizontal_absolute(n = 1)
-        control(n.to_s, 'G')
+        cmd = control(n.to_s, 'G')
+        cmd += control('1', 'D') if CLI::UI::OS.current.shift_cursor_on_line_reset?
+        cmd
       end
 
       # Show the cursor

--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -136,13 +136,17 @@ module CLI
       # Move to the next line
       #
       def self.next_line
-        cursor_down + control('1', 'G')
+        cmd = cursor_down + control('1', 'G')
+        cmd += control('1', 'D') if CLI::UI::OS.current.shift_cursor_on_line_reset?
+        cmd
       end
 
       # Move to the previous line
       #
       def self.previous_line
-        cursor_up + control('1', 'G')
+        cmd = cursor_up + control('1', 'G')
+        cmd += control('1', 'D') if CLI::UI::OS.current.shift_cursor_on_line_reset?
+        cmd
       end
 
       def self.clear_to_end_of_line

--- a/lib/cli/ui/frame/frame_style/box.rb
+++ b/lib/cli/ui/frame/frame_style/box.rb
@@ -138,11 +138,22 @@ module CLI
               # reset to column 1 so that things like ^C don't ruin formatting
               o << "\r"
 
+              # This code will print out a full line with the given preamble and
+              # suffix, as exemplified below.
+              #
+              # preamble_start                         suffix_start
+              # |                 preamble_end         |            suffix_end
+              # |                 |                    |            | termwidth
+              # |                 |                    |            | |
+              # V                 V                    V            V V
+              # --- Preamble text --------------------- suffix text --
               o << color.code
-              o << print_at_x(preamble_start, HORIZONTAL * (termwidth - preamble_start)) # draw a full line
-              o << print_at_x(preamble_start, preamble)
+              o << preamble
               o << color.code
-              o << print_at_x(suffix_start, suffix)
+              o << HORIZONTAL * (suffix_start - preamble_end)
+              o << suffix
+              o << HORIZONTAL * (termwidth - suffix_end)
+              o << color.code
               o << CLI::UI::Color::RESET.code
               o << CLI::UI::ANSI.show_cursor
               o << "\n"

--- a/lib/cli/ui/frame/frame_style/box.rb
+++ b/lib/cli/ui/frame/frame_style/box.rb
@@ -148,12 +148,10 @@ module CLI
               # V                 V                    V            V V
               # --- Preamble text --------------------- suffix text --
               o << color.code
-              o << preamble
+              o << print_at_x(preamble_start, HORIZONTAL * (termwidth - preamble_start)) # draw a full line
+              o << print_at_x(preamble_start, preamble)
               o << color.code
-              o << HORIZONTAL * (suffix_start - preamble_end)
-              o << suffix
-              o << HORIZONTAL * (termwidth - suffix_end)
-              o << color.code
+              o << print_at_x(suffix_start, suffix)
               o << CLI::UI::Color::RESET.code
               o << CLI::UI::ANSI.show_cursor
               o << "\n"

--- a/lib/cli/ui/glyph.rb
+++ b/lib/cli/ui/glyph.rb
@@ -16,7 +16,7 @@ module CLI
         end
       end
 
-      attr_reader :handle, :codepoint, :color, :char, :to_s, :fmt
+      attr_reader :handle, :codepoint, :color, :to_s, :fmt
 
       # Creates a new glyph
       #
@@ -24,12 +24,14 @@ module CLI
       #
       # * +handle+ - The handle in the +MAP+ constant
       # * +codepoint+ - The codepoint used to create the glyph (e.g. +0x2717+ for a ballot X)
+      # * +plain+ - A fallback plain string to be used in case glyphs are disabled
       # * +color+ - What color to output the glyph. Check +CLI::UI::Color+ for options.
       #
-      def initialize(handle, codepoint, color)
+      def initialize(handle, codepoint, plain, color)
         @handle    = handle
         @codepoint = codepoint
         @color     = color
+        @plain     = plain
         @char      = Array(codepoint).pack('U*')
         @to_s      = color.code + char + Color::RESET.code
         @fmt       = "{{#{color.name}:#{char}}}"
@@ -37,16 +39,24 @@ module CLI
         MAP[handle] = self
       end
 
+      # Fetches the actual character(s) to be displayed for a glyph, based on the current OS support
+      #
+      # ==== Returns
+      # Returns the glyph string
+      def char
+        CLI::UI::OS.current.supports_emoji? ? @char : @plain
+      end
+
       # Mapping of glyphs to terminal output
       MAP = {}
-      STAR      = new('*', 0x2b51,           Color::YELLOW) # YELLOW SMALL STAR (⭑)
-      INFO      = new('i', 0x1d4be,          Color::BLUE)   # BLUE MATHEMATICAL SCRIPT SMALL i (𝒾)
-      QUESTION  = new('?', 0x003f,           Color::BLUE)   # BLUE QUESTION MARK (?)
-      CHECK     = new('v', 0x2713,           Color::GREEN)  # GREEN CHECK MARK (✓)
-      X         = new('x', 0x2717,           Color::RED)    # RED BALLOT X (✗)
-      BUG       = new('b', 0x1f41b,          Color::WHITE)  # Bug emoji (🐛)
-      CHEVRON   = new('>', 0xbb,             Color::YELLOW) # RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK (»)
-      HOURGLASS = new('H', [0x231b, 0xfe0e], Color::BLUE)   # HOURGLASS + VARIATION SELECTOR 15 (⌛︎)
+      STAR      = new('*', 0x2b51,           '*', Color::YELLOW) # YELLOW SMALL STAR (⭑)
+      INFO      = new('i', 0x1d4be,          'i', Color::BLUE)   # BLUE MATHEMATICAL SCRIPT SMALL i (𝒾)
+      QUESTION  = new('?', 0x003f,           '?', Color::BLUE)   # BLUE QUESTION MARK (?)
+      CHECK     = new('v', 0x2713,           '√', Color::GREEN)  # GREEN CHECK MARK (✓)
+      X         = new('x', 0x2717,           'X', Color::RED)    # RED BALLOT X (✗)
+      BUG       = new('b', 0x1f41b,          '!', Color::WHITE)  # Bug emoji (🐛)
+      CHEVRON   = new('>', 0xbb,             '»', Color::YELLOW) # RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK (»)
+      HOURGLASS = new('H', [0x231b, 0xfe0e], 'H', Color::BLUE)   # HOURGLASS + VARIATION SELECTOR 15 (⌛︎)
 
       # Looks up a glyph by name
       #

--- a/lib/cli/ui/os.rb
+++ b/lib/cli/ui/os.rb
@@ -1,0 +1,63 @@
+module CLI
+  module UI
+    module OS
+      # Determines which OS is currently running the UI, to make it easier to
+      # adapt its behaviour to the features of the OS.
+      def self.current
+        @current_os ||= case RUBY_PLATFORM
+        when /darwin/
+          Mac
+        when /linux/
+          Linux
+        when /mingw32/
+          Windows
+        else
+          raise "Could not determine OS from platform #{RUBY_PLATFORM}"
+        end
+      end
+
+      class Mac
+        class << self
+          def supports_emoji?
+            true
+          end
+
+          def supports_color_prompt?
+            true
+          end
+
+          def supports_arrow_keys?
+            true
+          end
+
+          def shift_cursor_on_line_reset?
+            false
+          end
+        end
+      end
+
+      class Linux < Mac
+      end
+
+      class Windows
+        class << self
+          def supports_emoji?
+            false
+          end
+
+          def supports_color_prompt?
+            false
+          end
+
+          def supports_arrow_keys?
+            false
+          end
+
+          def shift_cursor_on_line_reset?
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -190,7 +190,13 @@ module CLI
           end
 
           raise(ArgumentError, 'insufficient options') if options.nil? || options.empty?
-          instructions = (multiple ? "Toggle options. " : "") + "Choose with ↑ ↓ ⏎"
+          navigate_text = if CLI::UI::OS.current.supports_arrow_keys?
+            "Choose with ↑ ↓ ⏎"
+          else
+            "Navigate up with 'k' and down with 'j', press Enter to select"
+          end
+
+          instructions = (multiple ? "Toggle options. " : "") + navigate_text
           instructions += ", filter with 'f'" if filter_ui
           instructions += ", enter option with 'e'" if select_ui && (options.size > 9)
           puts_question("#{question} {{yellow:(#{instructions})}}")
@@ -256,7 +262,10 @@ module CLI
           # thread to manage output, but the current strategy feels like a
           # better tradeoff.
           prefix = CLI::UI.with_frame_color(:blue) { CLI::UI::Frame.prefix }
-          prompt = prefix + CLI::UI.fmt('{{blue:> }}') + CLI::UI::Color::YELLOW.code
+          # If a prompt is interrupted on Windows it locks the colour of the terminal from that point on, so we should
+          # not change the colour here.
+          prompt = prefix + CLI::UI.fmt('{{blue:> }}')
+          prompt += CLI::UI::Color::YELLOW.code if CLI::UI::OS.current.supports_color_prompt?
 
           begin
             line = Readline.readline(prompt, true)

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -273,6 +273,7 @@ module CLI
             case char
             when ESC        ; @state = :esc
             when "\r", "\n" ; select_current
+            when "\b"       ; update_search(BACKSPACE) # Happens on Windows
             else            ; update_search(char)
             end
           when :line_select

--- a/lib/cli/ui/spinner.rb
+++ b/lib/cli/ui/spinner.rb
@@ -10,11 +10,11 @@ module CLI
       PERIOD = 0.1 # seconds
       TASK_FAILED = :task_failed
 
-      RUNES = %w(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏).freeze
+      RUNES = CLI::UI::OS.current.supports_emoji? ? %w(⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏).freeze : %w(\\ | / - \\ | / -).freeze
 
       begin
-        colors = [CLI::UI::Color::CYAN.code] * 5 + [CLI::UI::Color::MAGENTA.code] * 5
-        raise unless RUNES.size == colors.size
+        colors = [CLI::UI::Color::CYAN.code] * (RUNES.size / 2).ceil +
+          [CLI::UI::Color::MAGENTA.code] * (RUNES.size / 2).to_i
         GLYPHS = colors.zip(RUNES).map(&:join)
       end
 

--- a/test/cli/ui/ansi_test.rb
+++ b/test/cli/ui/ansi_test.rb
@@ -14,6 +14,19 @@ module CLI
         assert_equal(3, ANSI.printing_width(">🔧<"))
         assert_equal(1, ANSI.printing_width("👩‍💻"))
       end
+
+      def test_line_skip_with_shift
+        next_line_expected = "\e[1B\e[1G"
+        previous_line_expected = "\e[1A\e[1G"
+
+        assert_equal(next_line_expected, ANSI.next_line)
+        assert_equal(previous_line_expected, ANSI.previous_line)
+
+        CLI::UI::OS.stubs(:current).returns(CLI::UI::OS::Windows)
+
+        assert_equal("#{next_line_expected}\e[1D", ANSI.next_line)
+        assert_equal("#{previous_line_expected}\e[1D", ANSI.previous_line)
+      end
     end
   end
 end

--- a/test/cli/ui/glyph_test.rb
+++ b/test/cli/ui/glyph_test.rb
@@ -25,6 +25,34 @@ module CLI
         end
       end
 
+      def test_plain_glyphs
+        with_os_mock_and_reload(
+          CLI::UI::OS::Windows,
+          :Glyph,
+          File.join(File.dirname(__FILE__), '../../../lib/cli/ui/glyph.rb')
+        ) do
+          assert_equal("\x1b[33m*\x1b[0m", Glyph::STAR.to_s)
+          assert_equal("\x1b[94mi\x1b[0m", Glyph::INFO.to_s)
+          assert_equal("\x1b[94m?\x1b[0m", Glyph::QUESTION.to_s)
+          assert_equal("\x1b[32m√\x1b[0m", Glyph::CHECK.to_s)
+          assert_equal("\x1b[31mX\x1b[0m", Glyph::X.to_s)
+          assert_equal("\x1b[97m!\x1b[0m", Glyph::BUG.to_s)
+          assert_equal("\x1b[33m»\x1b[0m", Glyph::CHEVRON.to_s)
+
+          assert_equal(Glyph::STAR,     Glyph.lookup('*'))
+          assert_equal(Glyph::INFO,     Glyph.lookup('i'))
+          assert_equal(Glyph::QUESTION, Glyph.lookup('?'))
+          assert_equal(Glyph::CHECK,    Glyph.lookup('v'))
+          assert_equal(Glyph::X,        Glyph.lookup('x'))
+          assert_equal(Glyph::BUG,      Glyph.lookup('b'))
+          assert_equal(Glyph::CHEVRON,  Glyph.lookup('>'))
+
+          assert_raises(Glyph::InvalidGlyphHandle) do
+            Glyph.lookup('$')
+          end
+        end
+      end
+
       def test_useful_exception
         e = begin
           Glyph.lookup('$')

--- a/test/cli/ui/printer_test.rb
+++ b/test/cli/ui/printer_test.rb
@@ -25,6 +25,23 @@ module CLI
         end
       end
 
+      def test_frame_with_long_texts
+        overlong_preamble = 'This is a long preamble! '
+        overlong_preamble *= (CLI::UI::Terminal.width / overlong_preamble.length).floor + 1
+
+        overlong_suffix = 'This overlaps the suffix! '
+        overlong_suffix *= (CLI::UI::Terminal.width / overlong_suffix.length).floor + 1
+
+        Frame.open(overlong_preamble, success_text: overlong_suffix) do
+          out, _ = capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+            assert(Printer.puts('foo', frame_color: :red))
+          end
+
+          assert_equal("\e[31m┃ \e[0m\e[0mfoo\n", out)
+        end
+      end
+
       def test_puts_stream
         _, err = capture_io do
           assert(Printer.puts('foo', to: $stderr, format: false))

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -134,6 +134,24 @@ module CLI
         assert_result(expected_out, "", false)
       end
 
+      def test_confirm_no_arrow_keys
+        # Windows doesn't detect presses on the arrow keys when picking an option, so we don't show the instruction text
+        # for them.
+        with_os_mock_and_reload(CLI::UI::OS::Windows) do
+          _run('x', 'n') { Prompt.confirm('q') }
+          expected_out = strip_heredoc(<<-EOF) + ' '
+            ? q (Navigate up with 'k' and down with 'j', press Enter to select)
+            \e[?25l> 1. yes\e[K
+              2. no\e[K
+            #{' ' * CLI::UI::Terminal.width}
+            #{' ' * CLI::UI::Terminal.width}
+            \e[?25h\e[K
+            ? q (You chose: no)
+          EOF
+          assert_result(expected_out, "", false)
+        end
+      end
+
       def test_ask_free_form_happy_path
         _run('asdf') { Prompt.ask('q') }
         assert_result("? q\n> asdf\n", "", "asdf")

--- a/test/cli/ui/spinner_test.rb
+++ b/test/cli/ui/spinner_test.rb
@@ -68,6 +68,77 @@ module CLI
         )
       end
 
+      def test_spinner_without_emojis
+        with_os_mock_test do
+          out, err = capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+            CLI::UI::Spinner.spin('sleeping') do
+              sleep CLI::UI::Spinner::PERIOD * 2.5
+            end
+          end
+
+          assert_equal('', err)
+          match_lines(
+            out,
+            /\\ sleeping/,
+            /\|/,
+            /\//,
+            /√/
+          )
+        end
+      end
+
+      def test_async_without_emojis
+        with_os_mock_test do
+          out, err = capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+            spinner = CLI::UI::Spinner::Async.start('sleeping')
+            sleep CLI::UI::Spinner::PERIOD * 2.5
+            spinner.stop
+          end
+
+          assert_equal('', err)
+          match_lines(
+            out,
+            /\\ sleeping/,
+            /\|/,
+            /\//,
+            /√/
+          )
+        end
+      end
+
+      def test_updating_title_without_emojis
+        with_os_mock_test do
+          out, err = capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+            CLI::UI::Spinner.spin('私') do |task|
+              assert task
+              assert_respond_to task, :update_title
+              sleep CLI::UI::Spinner::PERIOD * 2.5
+              task.update_title('今日')
+              sleep CLI::UI::Spinner::PERIOD * 2.5
+              task.update_title('疲れたんだ')
+              sleep CLI::UI::Spinner::PERIOD * 2.5
+            end
+          end
+
+          assert_empty(err)
+          match_lines(
+            out,
+            /\\ 私/,
+            /\|/,
+            /\//,
+            /- 今日/,
+            /\\/,
+            /\| 疲れたんだ/,
+            /\//,
+            /-/,
+            /√/,
+          )
+        end
+      end
+
       def test_spinner_task_error_through_raising_exception
         out, err = capture_io do
           CLI::UI::StdoutRouter.ensure_activated
@@ -122,6 +193,22 @@ module CLI
       end
 
       private
+
+      def with_os_mock_test
+        classes = [:Spinner, :Glyph]
+
+        root_path = File.join(File.dirname(__FILE__), '../../../lib/cli/ui')
+        files = [
+          File.join(root_path, 'spinner.rb'),
+          File.join(root_path, 'glyph.rb'),
+        ]
+
+        Dir.glob(File.join(root_path, 'spinner', '*')).each do |file|
+          files << file
+        end
+
+        with_os_mock_and_reload(CLI::UI::OS::Windows, classes, files) { yield }
+      end
 
       def printable(str)
         str.gsub(/\x1b\[[\d;]+\w/, '')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,35 @@ require 'cli/ui'
 # Otherwise, results will vary depending on the context in which we run tests.
 CLI::UI.enable_color = true
 
+module CLI
+  module UI
+    module OS
+      # Default to Mac behaviour so running the tests in different environments doesn't lead to different outputs
+      def current
+        CLI::UI::OS::Mac
+      end
+    end
+  end
+end
+
+# Unloads the given classes from CLI::UI, reloads them and stubs the OS to the given one. This is used to run tests
+# on classes with variables that depend on the OS (e.g. Glyph), so that we can mock their state in the context of this
+# block.
+def with_os_mock_and_reload(os, class_names = [], files = [])
+  class_names = Array(class_names)
+  files = Array(files)
+
+  CLI::UI::OS.stubs(:current).returns(os)
+  class_names.each { |classname| CLI::UI.send(:remove_const, classname) }
+  files.each { |file| load(file) }
+
+  yield
+ensure
+  CLI::UI::OS.unstub(:current)
+  class_names.each { |classname| CLI::UI.send(:remove_const, classname) }
+  files.each { |file| load(file) }
+end
+
 require 'fileutils'
 require 'tmpdir'
 require 'tempfile'


### PR DESCRIPTION
This PR fixes the issues that occur when a box is printed with too long preambles or suffixes so that they overlap with the next elements in the line. The changes to support the UI on Windows failed on negative indexes that happened because of those extra-long lines.

I've reverted the box code to what it was before, and instead simply shift the cursor back on Windows.

After these changes:
```
irb(main):002:0> CLI::UI::Frame.open(('aa'..'zz').to_a.join)
┏━━ aaabacadaeafagahaiajakalamanaoapaqarasatauavawaxayazbabbbcbdbebfbgbhbibjbkblbmbnbobpbqbrbsbtbubvbwbxbybzcacbcccdcecfcgchcicjckclcmcncocpcqcrcsctcucvcwcxcyczdadbdcdddedfdgdhdidjdkdldmdndodpdqdrdsdtdudvdwdxdydzeaebecedeeefegeheiejekelemeneoepeqereseteuevewexeyezfafbfcfdfefffgfhfifjfkflfmfnfofpfqfrfsftfufvfwfxfyfzgagbgcgdgegfggghgigjgkglgmgngogpgqgrgsgtgugvgwgxgygzhahbhchdhehfhghhhihjhkhlhmhnhohphqhrhshthuhvhwhxhyhziaibicidieifigihiiijikiliminioipiqirisitiuiviwixiyizjajbjcjdjejfjgjhjijjjkjljmjnjojpjqjrjsjtjujvjwjxjyjzkakbkckdkekfkgkhkikjkkklkmknkokpkqkrksktkukvkwkxkykzlalblcldlelflglhliljlklllmlnlolplqlrlsltlulvlwlxlylzmambmcmdmemfmgmhmimjmkmlmmmnmompmqmrmsmtmumvmwmxmymznanbncndnenfngnhninjnknlnmnnnonpnqnrnsntnunvnwnxnynzoaobocodoeofogohoiojokolomonooopoqorosotouovowoxoyozpapbpcpdpepfpgphpipjpkplpmpnpopppqprpsptpupvpwpxpypzqaqbqcqdqeqfqgqhqiqjqkqlqmqnqoqpqqqrqsqtquqvqwqxqyqzrarbrcrdrerfrgrhrirjrkrlrmrnrorprqrrrsrtrurvrwrxryrzsasbscsdsesfsgshsisjskslsmsnsospsqsrssstsusvswsxsysztatbtctdtetftgthtitjtktltmtntotptqtrtstttutvtwtxtytzuaubucudueufuguhuiujukulumunuoupuqurusutuuuvuwuxuyuzvavbvcvdvevfvgvhvivjvkvlvmvnvovpvqvrvsvtvuvvvwvxvyvzwawbwcwdwewfwgwhwiwjwkwlwmwnwowpwqwrwswtwuwvwwwxwywzxaxbxcxdxexfxgxhxixjxkxlxmxnxoxpxqxrxsxtxuxvxwxxxyxzyaybycydyeyfygyhyiyjykylymynyoypyqyrysytyuyvywyxyyyzzazbzczdzezfzgzhzizjzkzlzmznzozpzqzrzsztzuzvzwzxzyzz
```