### PR TITLE
Clean up StackItems

### DIFF
--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -28,7 +28,7 @@ module CLI
     end
 
     # Color resolution using +CLI::UI::Color.lookup+
-    # Will lookup using +Color.lookup+ if a symbol, otherwise we assume it is a valid color and return it
+    # Will lookup using +Color.lookup+ unless it's already a CLI::UI::Color (or nil)
     #
     # ==== Attributes
     #
@@ -36,26 +36,25 @@ module CLI
     #
     def self.resolve_color(input)
       case input
-      when Symbol
-        CLI::UI::Color.lookup(input)
-      else
+      when CLI::UI::Color, nil
         input
+      else
+        CLI::UI::Color.lookup(input)
       end
     end
 
     # Frame style resolution using +CLI::UI::Frame::FrameStyle.lookup+.
-    # Will lookup using +FrameStyle.lookup+ if the input is a symbol.  Otherwise,
-    # we assume it's a valid FrameStyle
+    # Will lookup using +FrameStyle.lookup+ unless it's already a CLI::UI::Frame::FrameStyle(or nil)
     #
     # ==== Attributes
     #
     # * +input+ - frame style to resolve
     def self.resolve_style(input)
       case input
-      when Symbol
-        CLI::UI::Frame::FrameStyle.lookup(input)
-      else
+      when CLI::UI::Frame::FrameStyle, nil
         input
+      else
+        CLI::UI::Frame::FrameStyle.lookup(input)
       end
     end
 

--- a/lib/cli/ui/frame/frame_stack.rb
+++ b/lib/cli/ui/frame/frame_stack.rb
@@ -5,13 +5,12 @@ module CLI
         COLOR_ENVVAR = 'CLI_FRAME_STACK'
         STYLE_ENVVAR = 'CLI_STYLE_STACK'
 
-        StackItem = Struct.new(:color_name, :style_name) do
-          def color
-            @color ||= CLI::UI.resolve_color(color_name)
-          end
+        class StackItem
+          attr_reader :color, :frame_style
 
-          def frame_style
-            @frame_style ||= CLI::UI.resolve_style(style_name)
+          def initialize(color_name, style_name)
+            @color = CLI::UI.resolve_color(color_name)
+            @frame_style = CLI::UI.resolve_style(style_name)
           end
         end
 
@@ -55,7 +54,7 @@ module CLI
               end
             end
 
-            item ||= StackItem.new(color.name, style.name)
+            item ||= StackItem.new(color, style)
 
             curr = items
             curr << item
@@ -85,8 +84,8 @@ module CLI
             styles = []
 
             items.each do |item|
-              colors << item.color_name
-              styles << item.style_name
+              colors << item.color.name
+              styles << item.frame_style.name
             end
 
             ENV[COLOR_ENVVAR] = colors.join(':')

--- a/lib/cli/ui/frame/frame_style.rb
+++ b/lib/cli/ui/frame/frame_style.rb
@@ -39,7 +39,7 @@ module CLI
           def message
             keys = FrameStyle.loaded_styles.map(&:inspect).join(',')
             "invalid frame style: #{@name.inspect}" \
-              "-- must be one of CLI::UI::Frame::FrameStyle.loaded_styles " \
+              " -- must be one of CLI::UI::Frame::FrameStyle.loaded_styles " \
               "(#{keys})"
           end
         end


### PR DESCRIPTION
Motivated by the desire to have `StackItem`s raise at initialization when they're invalid to make it easier to track down a bug where that's happening.