### PR TITLE
Update example of Printer.puts

### DIFF
--- a/lib/cli/ui/printer.rb
+++ b/lib/cli/ui/printer.rb
@@ -25,7 +25,7 @@ module CLI
       #
       # ==== Example
       #
-      #   CLI::UI::Printer.puts('{x} Ouch', stream: $stderr, color: :red)
+      #   CLI::UI::Printer.puts('{{x}} Ouch', to: $stderr)
       #
       def self.puts(msg, frame_color: nil, to: $stdout, encoding: Encoding::UTF_8, format: true, graceful: true)
         msg = (+msg).force_encoding(encoding) if encoding


### PR DESCRIPTION
`:stream` and `:color` parameters no longer exist, so I rewrited example to match current version.