### PR TITLE
Resolve windows navigation error

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -334,20 +334,13 @@ module CLI
         end
 
         def read_char
-          raw_tty! do
-            getc = $stdin.getc
-            getc ? getc.chr : :timeout
+          if $stdin.tty? && !ENV['TEST']
+            $stdin.getch # raw mode for tty
+          else
+            $stdin.getc
           end
         rescue IOError
           "\e"
-        end
-
-        def raw_tty!
-          if ENV['TEST'] || !$stdin.tty?
-            yield
-          else
-            $stdin.raw { yield }
-          end
         end
 
         def presented_options(recalculate: false)


### PR DESCRIPTION
Only works for Ruby 2.7 and up

Windows users would face a queued up "return" character when navigating after filtering options. @paulomarg and I found that instead of using `$stdin.getc`, `$stdin.getch` resolves this issue.