### PR TITLE
Include only important files in a gem build.

### DIFF
--- a/cli-ui.gemspec
+++ b/cli-ui.gemspec
@@ -14,9 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/shopify/cli-ui'
   spec.license       = 'MIT'
 
-  spec.files = %x(git ls-files -z).split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = Dir['lib/**/*.rb', 'README.md', 'LICENSE.txt']
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
I tried packaging the gem for openSUSE to have it as a dependency for a project of mine, which worked.
The [build log](https://build.opensuse.org/package/live_build_log/home:expeehaa/rubygem-cli-ui/openSUSE_Tumbleweed/x86_64) shows some warnings though:

```
[   18s] ruby2.7-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/2.7.0/gems/cli-ui-1.5.0/.dependabot
[   18s] ruby2.7-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/2.7.0/gems/cli-ui-1.5.0/.dependabot
[   18s] ruby2.7-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/2.7.0/gems/cli-ui-1.5.0/.github
[   18s] ruby2.7-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/2.7.0/gems/cli-ui-1.5.0/.github
[   18s] ruby2.7-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/2.7.0/gems/cli-ui-1.5.0/.rubocop.yml
[   18s] ruby2.7-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/2.7.0/gems/cli-ui-1.5.0/.travis.yml
[   18s] ruby3.0-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/3.0.0/gems/cli-ui-1.5.0/.dependabot
[   18s] ruby3.0-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/3.0.0/gems/cli-ui-1.5.0/.dependabot
[   18s] ruby3.0-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/3.0.0/gems/cli-ui-1.5.0/.github
[   18s] ruby3.0-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/3.0.0/gems/cli-ui-1.5.0/.github
[   18s] ruby3.0-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/3.0.0/gems/cli-ui-1.5.0/.rubocop.yml
[   18s] ruby3.0-rubygem-cli-ui.x86_64: W: hidden-file-or-dir /usr/lib64/ruby/gems/3.0.0/gems/cli-ui-1.5.0/.travis.yml
[   18s] The file or directory is hidden. You should see if this is normal, and delete
[   18s] it from the package if not.
[   18s] 
[   18s] ruby2.7-rubygem-cli-ui.x86_64: W: version-control-internal-file /usr/lib64/ruby/gems/2.7.0/gems/cli-ui-1.5.0/.gitignore
[   18s] ruby3.0-rubygem-cli-ui.x86_64: W: version-control-internal-file /usr/lib64/ruby/gems/3.0.0/gems/cli-ui-1.5.0/.gitignore
[   18s] You have included file(s) internally used by a version control system in the
[   18s] package. Move these files out of the package and rebuild it.
```

Since many of the files currently included in the published gem are not relevant for any user, I replaced `git ls-files` with a slightly more precise definition of which files should be included.