### PR TITLE
Add compatibility for Ruby 3.0.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ rvm:
   - 2.5.8
   - 2.6.6
   - 2.7.1
+  - 3.0.0
   - jruby-9.2.14.0
 before_install: gem update --system

--- a/test/cli/ui/progress_test.rb
+++ b/test/cli/ui/progress_test.rb
@@ -35,7 +35,7 @@ module CLI
 
         out, = capture_io do
           bar = Progress.new(width: 10 + suffix.size) # each 10% is one box with this width
-          bar.tick(params)
+          bar.tick(**params)
           assert_equal(expected_bar, bar.to_s)
         end
 


### PR DESCRIPTION
It seems like the library itself works out-of-the-box with ruby 3.0.0. Only one test had to be adjusted.