### PR TITLE
[Fix] Refactor color formatting

### DIFF
--- a/lib/cli/ui/color.rb
+++ b/lib/cli/ui/color.rb
@@ -20,30 +20,49 @@ module CLI
         @name = name
       end
 
-      RED     = new('31', :red)
-      GREEN   = new('32', :green)
-      YELLOW  = new('33', :yellow)
+      BLACK     = new('90', :black)
+      RED       = new('31', :red)
+      GREEN     = new('32', :green)
+      YELLOW    = new('33', :yellow)
       # default blue is low-contrast against black in some default terminal color scheme
-      BLUE    = new('94', :blue) # 9x = high-intensity fg color x
-      MAGENTA = new('35', :magenta)
-      CYAN    = new('36', :cyan)
-      RESET   = new('0',  :reset)
-      BOLD    = new('1',  :bold)
-      WHITE   = new('97', :white)
+      BLUE      = new('94', :blue) # 9x = high-intensity fg color x
+      MAGENTA   = new('35', :magenta)
+      CYAN      = new('36', :cyan)
+      WHITE     = new('97', :white)
+      RESET     = new('0',  :reset)
+      BOLD      = new('1',  :bold)
+      ITALIC    = new('2',  :italic)
+      UNDERLINE = new('3',  :underline)
 
       # 240 is very dark gray; 255 is very light gray. 244 is somewhat dark.
-      GRAY = new('38;5;244', :grey)
+      GRAY = new('38;5;244', :gray)
+      GREY = GRAY
 
       MAP = {
+        black: BLACK,
         red: RED,
         green: GREEN,
         yellow: YELLOW,
         blue: BLUE,
         magenta: MAGENTA,
         cyan: CYAN,
+        white: WHITE,
+
         reset: RESET,
         bold: BOLD,
+        italic: ITALIC,
+        underline: UNDERLINE,
+
+        # i18n english colors
         gray: GRAY,
+        grey: GRAY,
+
+        # semantic
+        error: RED,
+        success: GREEN,
+        warning: YELLOW,
+        info: BLUE,
+        command: CYAN
       }.freeze
 
       class InvalidColorName < ArgumentError

--- a/lib/cli/ui/color.rb
+++ b/lib/cli/ui/color.rb
@@ -62,7 +62,7 @@ module CLI
         success: GREEN,
         warning: YELLOW,
         info: BLUE,
-        command: CYAN
+        command: CYAN,
       }.freeze
 
       class InvalidColorName < ArgumentError

--- a/lib/cli/ui/formatter.rb
+++ b/lib/cli/ui/formatter.rb
@@ -10,27 +10,8 @@ module CLI
       # There are presentational (colours and formatters)
       # and semantic (error, info, command) formatters available
       #
-      SGR_MAP = {
-        # presentational
-        'red' => '31',
-        'green' => '32',
-        'yellow' => '33',
-        # default blue is low-contrast against black in some default terminal color scheme
-        'blue' => '94', # 9x = high-intensity fg color x
-        'magenta' => '35',
-        'cyan' => '36',
-        'bold' => '1',
-        'italic' => '3',
-        'underline' => '4',
-        'reset' => '0',
-
-        # semantic
-        'error' => '31', # red
-        'success' => '32', # success
-        'warning' => '33', # yellow
-        'info' => '94', # bright blue
-        'command' => '36', # cyan
-      }.freeze
+      # TODO: deprecate SGR_MAP since Color::MAP has all the relevant values
+      SGR_MAP = Color::MAP.map{|key,value| [key.to_s, value.sgr] }.to_h.freeze
 
       BEGIN_EXPR = '{{'
       END_EXPR   = '}}'

--- a/lib/cli/ui/formatter.rb
+++ b/lib/cli/ui/formatter.rb
@@ -11,7 +11,7 @@ module CLI
       # and semantic (error, info, command) formatters available
       #
       # TODO: deprecate SGR_MAP since Color::MAP has all the relevant values
-      SGR_MAP = Color::MAP.map{|key,value| [key.to_s, value.sgr] }.to_h.freeze
+      SGR_MAP = Color::MAP.map { |key, value| [key.to_s, value.sgr] }.to_h.freeze
 
       BEGIN_EXPR = '{{'
       END_EXPR   = '}}'


### PR DESCRIPTION
Refactor color formatting
* unify the `CLI::UI::Formatter` class to use `CLI::UI::Color`
* add colors `grey` (and `gray`), `white`, `black`
* add `italic` and `underline`
* add semantic names such as `error`, `success`, `warning`, `info` and `command`