### PR TITLE
[fix] formatting errors raises exceptions

### DIFF
--- a/lib/cli/ui/formatter.rb
+++ b/lib/cli/ui/formatter.rb
@@ -116,7 +116,7 @@ module CLI
               "invalid format specifier: #{name}",
               @text,
               -1
-            )
+            ) if ENV['TEST']
           end
         end
         CLI::UI::ANSI.sgr(sgr) + text

--- a/test/cli/ui/formatter_test.rb
+++ b/test/cli/ui/formatter_test.rb
@@ -33,6 +33,14 @@ module CLI
 
       def test_invalid_funcname
         input = '{{nope:text}}'
+        expected = "\e[0;mtext\e[0m"
+        actual = CLI::UI::Formatter.new(input).format
+        assert_equal(expected, actual)
+      end
+
+      def test_invalid_funcname_testenv
+        ENV['TEST'] = '1'
+        input = '{{nope:text}}'
         ex = assert_raises(CLI::UI::Formatter::FormatError) do
           CLI::UI::Formatter.new(input).format
         end


### PR DESCRIPTION
* invalid formatting is now gracefully ignored and won't interrupt CLI execution
* TEST ENV will raise an exception as before