### PR TITLE
update bundler to 2.2.22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,4 +57,4 @@ DEPENDENCIES
   rubocop-shopify
 
 BUNDLED WITH
-   2.1.0
+   2.2.22


### PR DESCRIPTION
This PR updates Bundler to 2.2.22 and regenerates the Gemfile.lock to explicitly define the source of each gem.