### PR TITLE
Continue best-effort support of jruby without ci

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        ruby-version: ['2.6', '2.7', '3.0', 'jruby']
+        ruby-version: ['2.6', '2.7', '3.0']
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
jruby ci takes 3 min vs 20-30 seconds for others.