### PR TITLE
Stop changing the frame color for any prompt

### DIFF
--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -167,21 +167,19 @@ module CLI
         def ask_password(question)
           require 'io/console'
 
-          CLI::UI.with_frame_color(:blue) do
-            STDOUT.print(CLI::UI.fmt('{{?}} ' + question)) # Do not use puts_question to avoid the new line.
+          STDOUT.print(CLI::UI.fmt('{{?}} ' + question)) # Do not use puts_question to avoid the new line.
 
-            # noecho interacts poorly with Readline under system Ruby, so do a manual `gets` here.
-            # No fancy Readline integration (like echoing back) is required for a password prompt anyway.
-            password = STDIN.noecho do
-              # Chomp will remove the one new line character added by `gets`, without touching potential extra spaces:
-              # " 123 \n".chomp => " 123 "
-              T.must(STDIN.gets).chomp
-            end
-
-            STDOUT.puts # Complete the line
-
-            password
+          # noecho interacts poorly with Readline under system Ruby, so do a manual `gets` here.
+          # No fancy Readline integration (like echoing back) is required for a password prompt anyway.
+          password = STDIN.noecho do
+            # Chomp will remove the one new line character added by `gets`, without touching potential extra spaces:
+            # " 123 \n".chomp => " 123 "
+            T.must(STDIN.gets).chomp
           end
+
+          STDOUT.puts # Complete the line
+
+          password
         end
 
         # Asks the user a yes/no question.
@@ -314,9 +312,7 @@ module CLI
 
         sig { params(str: String).void }
         def puts_question(str)
-          CLI::UI.with_frame_color(:blue) do
-            STDOUT.puts(CLI::UI.fmt('{{?}} ' + str))
-          end
+          STDOUT.puts(CLI::UI.fmt('{{?}} ' + str))
         end
 
         sig { params(is_file: T::Boolean).returns(String) }
@@ -333,7 +329,7 @@ module CLI
           # work. We could work around this by having CLI::UI use a pipe and a
           # thread to manage output, but the current strategy feels like a
           # better tradeoff.
-          prefix = CLI::UI.with_frame_color(:blue) { CLI::UI::Frame.prefix }
+          prefix = CLI::UI::Frame.prefix
           # If a prompt is interrupted on Windows it locks the colour of the terminal from that point on, so we should
           # not change the colour here.
           prompt = prefix + CLI::UI.fmt('{{blue:> }}')

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -485,11 +485,7 @@ module CLI
             "Filter: #{filter_text}"
           end
 
-          if metadata_text
-            CLI::UI.with_frame_color(:blue) do
-              puts CLI::UI.fmt("  {{green:#{metadata_text}}}#{ANSI.clear_to_end_of_line}")
-            end
-          end
+          puts CLI::UI.fmt("  {{green:#{metadata_text}}}#{ANSI.clear_to_end_of_line}") if metadata_text
 
           options.each do |choice, num|
             is_chosen = @multiple && num && @chosen[num - 1] && num != 0
@@ -512,9 +508,7 @@ module CLI
               message = message.split("\n").map { |l| "{{#{color}:> #{l.strip}}}" }.join("\n")
             end
 
-            CLI::UI.with_frame_color(:blue) do
-              puts CLI::UI.fmt(message)
-            end
+            puts CLI::UI.fmt(message)
           end
         end
 


### PR DESCRIPTION
It's surprising, and not necessary. Anyone wishing to change the frame color can now put their prompt inside a

```ruby
CLI::UI.with_frame_color(:blue) do
  ...
end
```

to take control, which wasn't previously an option. The previous behaviour wasn't even a reliable change, since the prompts can occur outside of frames.

Fixes #271.