### PR TITLE
✨ Allow to set a success_debrief to debrief successful tasks

### DIFF
--- a/lib/cli/ui/spinner.rb
+++ b/lib/cli/ui/spinner.rb
@@ -61,7 +61,7 @@ module CLI
         #
         # ==== Options
         #
-        # * +:auto_debrief+ - Automatically debrief exceptions? Default to true
+        # * +:auto_debrief+ - Automatically debrief exceptions or through success_debrief? Default to true
         #
         # ==== Block
         #

--- a/test/cli/ui/spinner/spin_group_test.rb
+++ b/test/cli/ui/spinner/spin_group_test.rb
@@ -33,6 +33,23 @@ module CLI
 
           assert_equal('', err)
         end
+
+        def test_spin_group_success_debrief
+          capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+
+            debriefer = ->(title, out, err) {}
+            sg = SpinGroup.new
+            sg.success_debrief(&debriefer)
+            debriefer.expects(:call).with('s', "Task output\n", '').once
+            sg.add('s') do
+              puts('Task output')
+              true
+            end
+
+            assert(sg.wait)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This allows users to specify if they want some kind of debrief, even when the tasks succeed.

Closes #355