### PR TITLE
Add support for interactive prompts in SpinGroup

### DIFF
--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -143,6 +143,11 @@ module CLI
           control('?1049', 'l')
         end
 
+        sig { returns(Regexp) }
+        def match_alternate_screen
+          /#{Regexp.escape(control('?1049', ''))}[hl]/
+        end
+
         # Show the cursor
         #
         sig { returns(String) }

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -222,18 +222,22 @@ module CLI
         #   CLI::UI::Prompt.any_key('Press RETURN to continue...') # Then check if that's what they pressed
         sig { params(prompt: String).returns(T.nilable(String)) }
         def any_key(prompt = 'Press any key to continue...')
-          puts_question(prompt)
-          read_char
+          CLI::UI::StdoutRouter::Capture.uncaptured do
+            puts_question(prompt)
+            read_char
+          end
         end
 
         # Wait for any key to be pressed, returning the pressed key.
         sig { returns(T.nilable(String)) }
         def read_char
-          if $stdin.tty? && !ENV['TEST']
-            require 'io/console'
-            $stdin.getch # raw mode for tty
-          else
-            $stdin.getc # returns nil at end of input
+          CLI::UI::StdoutRouter::Capture.uncaptured do
+            if $stdin.tty? && !ENV['TEST']
+              require 'io/console'
+              $stdin.getch # raw mode for tty
+            else
+              $stdin.getc # returns nil at end of input
+            end
           end
         rescue Errno::EIO, Errno::EPIPE, IOError
           "\e"
@@ -250,23 +254,25 @@ module CLI
             raise(ArgumentError, 'conflicting arguments: default enabled but allow_empty is false')
           end
 
-          if default
-            puts_question("#{question} (empty = #{default})")
-          else
-            puts_question(question)
-          end
-
-          # Ask a free form question
-          loop do
-            line = readline(is_file: is_file)
-
-            if line.empty? && default
-              write_default_over_empty_input(default)
-              return default
+          CLI::UI::StdoutRouter::Capture.uncaptured do
+            if default
+              puts_question("#{question} (empty = #{default})")
+            else
+              puts_question(question)
             end
 
-            if !line.empty? || allow_empty
-              return line
+            # Ask a free form question
+            loop do
+              line = readline(is_file: is_file)
+
+              if line.empty? && default
+                write_default_over_empty_input(default)
+                return default
+              end
+
+              if !line.empty? || allow_empty
+                return line
+              end
             end
           end
         end
@@ -301,33 +307,36 @@ module CLI
           instructions = (multiple ? 'Toggle options. ' : '') + navigate_text
           instructions += ", filter with 'f'" if filter_ui
           instructions += ", enter option with 'e'" if select_ui && (options.size > 9)
-          puts_question("#{question} " + instructions_color.code + "(#{instructions})" + Color::RESET.code)
-          resp = interactive_prompt(options, multiple: multiple, default: default)
 
-          # Clear the line
-          print(ANSI.previous_line + ANSI.clear_to_end_of_line)
-          # Force StdoutRouter to prefix
-          print(ANSI.previous_line + "\n")
+          CLI::UI::StdoutRouter::Capture.uncaptured do
+            puts_question("#{question} " + instructions_color.code + "(#{instructions})" + Color::RESET.code)
+            resp = interactive_prompt(options, multiple: multiple, default: default)
 
-          # reset the question to include the answer
-          resp_text = case resp
-          when Array
-            case resp.size
-            when 0
-              '<nothing>'
-            when 1..2
-              resp.join(' and ')
+            # Clear the line
+            print(ANSI.previous_line + ANSI.clear_to_end_of_line)
+            # Force StdoutRouter to prefix
+            print(ANSI.previous_line + "\n")
+
+            # reset the question to include the answer
+            resp_text = case resp
+            when Array
+              case resp.size
+              when 0
+                '<nothing>'
+              when 1..2
+                resp.join(' and ')
+              else
+                "#{resp.size} items"
+              end
             else
-              "#{resp.size} items"
+              resp
             end
-          else
+            puts_question("#{question} (You chose: {{italic:#{resp_text}}})")
+
+            return T.must(handler).call(resp) if block_given?
+
             resp
           end
-          puts_question("#{question} (You chose: {{italic:#{resp_text}}})")
-
-          return T.must(handler).call(resp) if block_given?
-
-          resp
         end
 
         # Useful for stubbing in tests
@@ -336,7 +345,9 @@ module CLI
             .returns(T.any(T::Array[String], String))
         end
         def interactive_prompt(options, multiple: false, default: nil)
-          InteractiveOptions.call(options, multiple: multiple, default: default)
+          CLI::UI::StdoutRouter::Capture.uncaptured do
+            InteractiveOptions.call(options, multiple: multiple, default: default)
+          end
         end
 
         sig { params(default: String).void }

--- a/lib/cli/ui/stdout_router.rb
+++ b/lib/cli/ui/stdout_router.rb
@@ -2,6 +2,7 @@
 
 require 'cli/ui'
 require 'stringio'
+require_relative '../../../vendor/reentrant_mutex'
 
 module CLI
   module UI
@@ -35,7 +36,11 @@ module CLI
 
           T.unsafe(@stream).write_without_cli_ui(*prepend_id(@stream, args))
           if (dup = StdoutRouter.duplicate_output_to)
-            T.unsafe(dup).write(*prepend_id(dup, args))
+            begin
+              T.unsafe(dup).write(*prepend_id(dup, args))
+            rescue IOError
+              # Ignore
+            end
           end
         end
 
@@ -86,21 +91,69 @@ module CLI
       class Capture
         extend T::Sig
 
-        @m = Mutex.new
+        @m = ReentrantMutex.new
         @active_captures = 0
         @saved_stdin = nil
 
         class << self
           extend T::Sig
 
+          sig { returns(T.nilable(Capture)) }
+          def current_capture
+            Thread.current[:cliui_current_capture]
+          end
+
+          sig { returns(Capture) }
+          def current_capture!
+            T.must(current_capture)
+          end
+
+          sig { type_parameters(:T).params(block: T.proc.returns(T.type_parameter(:T))).returns(T.type_parameter(:T)) }
+          def uncaptured(&block)
+            stdin_synchronize do
+              previous_print_captured_output = current_capture&.print_captured_output
+              current_capture&.print_captured_output = true
+              Spinner::SpinGroup.pause_spinners do
+                if outermost_uncaptured?
+                  begin
+                    prev_hook = Thread.current[:cliui_output_hook]
+                    Thread.current[:cliui_output_hook] = nil
+                    CLI::UI.raw do
+                      puts("#{ANSI.enter_alternate_screen}#{current_capture!.stdout}", wrap: false)
+                    end
+                  ensure
+                    Thread.current[:cliui_output_hook] = prev_hook
+                  end
+                end
+                block.call
+              ensure
+                print(ANSI.exit_alternate_screen) if outermost_uncaptured?
+              end
+            ensure
+              current_capture&.print_captured_output = !!previous_print_captured_output
+            end
+          end
+
+          sig { params(block: T.proc.void).void }
+          def stdin_synchronize(&block)
+            @m.synchronize do
+              case $stdin
+              when BlockingInput
+                $stdin.synchronize do
+                  block.call
+                end
+              else
+                block.call
+              end
+            end
+          end
+
           sig { type_parameters(:T).params(block: T.proc.returns(T.type_parameter(:T))).returns(T.type_parameter(:T)) }
           def with_stdin_masked(&block)
             @m.synchronize do
               if @active_captures.zero?
                 @saved_stdin = $stdin
-                $stdin, w = IO.pipe
-                $stdin.close
-                w.close
+                $stdin = BlockingInput.new(@saved_stdin)
               end
               @active_captures += 1
             end
@@ -114,20 +167,38 @@ module CLI
               end
             end
           end
+
+          private
+
+          sig { returns(T::Boolean) }
+          def outermost_uncaptured?
+            @m.count == 1 && $stdin.is_a?(BlockingInput)
+          end
         end
 
         sig do
-          params(with_frame_inset: T::Boolean, block: T.proc.void).void
+          params(
+            with_frame_inset: T::Boolean,
+            merged_output: T::Boolean,
+            duplicate_output_to: IO,
+            block: T.proc.void,
+          ).void
         end
-        def initialize(with_frame_inset: true, &block)
+        def initialize(
+          with_frame_inset: true,
+          merged_output: false,
+          duplicate_output_to: File.open(File::NULL, 'w'),
+          &block
+        )
           @with_frame_inset = with_frame_inset
+          @merged_output = merged_output
+          @duplicate_output_to = duplicate_output_to
           @block = block
-          @stdout = ''
-          @stderr = ''
+          @print_captured_output = false
         end
 
-        sig { returns(String) }
-        attr_reader :stdout, :stderr
+        sig { returns(T::Boolean) }
+        attr_accessor :print_captured_output
 
         sig { returns(T.untyped) }
         def run
@@ -135,8 +206,9 @@ module CLI
 
           StdoutRouter.assert_enabled!
 
-          out = StringIO.new
-          err = StringIO.new
+          Thread.current[:cliui_current_capture] = self
+          @out = StringIO.new
+          @err = StringIO.new
 
           prev_frame_inset = Thread.current[:no_cliui_frame_inset]
           prev_hook = Thread.current[:cliui_output_hook]
@@ -148,24 +220,90 @@ module CLI
           self.class.with_stdin_masked do
             Thread.current[:no_cliui_frame_inset] = !@with_frame_inset
             Thread.current[:cliui_output_hook] = ->(data, stream) do
+              stream = :stdout if @merged_output
               case stream
-              when :stdout then out.write(data)
-              when :stderr then err.write(data)
+              when :stdout
+                @out.write(data)
+                @duplicate_output_to.write(data)
+              when :stderr
+                @err.write(data)
               else raise
               end
-              false # suppress writing to terminal
+              print_captured_output # suppress writing to terminal by default
             end
 
-            begin
-              @block.call
-            ensure
-              @stdout = out.string
-              @stderr = err.string
-            end
+            @block.call
           end
         ensure
           Thread.current[:cliui_output_hook] = prev_hook
           Thread.current[:no_cliui_frame_inset] = prev_frame_inset
+          Thread.current[:cliui_current_capture] = nil
+        end
+
+        sig { returns(String) }
+        def stdout
+          @out.string
+        end
+
+        sig { returns(String) }
+        def stderr
+          @err.string
+        end
+
+        class BlockingInput
+          extend T::Sig
+
+          sig { params(stream: IO).void }
+          def initialize(stream)
+            @stream = stream
+            @m = ReentrantMutex.new
+          end
+
+          sig { void }
+          def synchronize
+            @m.synchronize do
+              previous_allowed_to_read = Thread.current[:cliui_allowed_to_read]
+              Thread.current[:cliui_allowed_to_read] = true
+              yield
+            ensure
+              Thread.current[:cliui_allowed_to_read] = previous_allowed_to_read
+            end
+          end
+
+          READING_METHODS = [
+            :each,
+            :each_byte,
+            :each_char,
+            :each_codepoint,
+            :each_line,
+            :getbyte,
+            :getc,
+            :getch,
+            :gets,
+            :read,
+            :read_nonblock,
+            :readbyte,
+            :readchar,
+            :readline,
+            :readlines,
+            :readpartial,
+          ]
+
+          NON_READING_METHODS = IO.instance_methods(false) - READING_METHODS
+
+          READING_METHODS.each do |method|
+            define_method(method) do |*args, **kwargs, &block|
+              raise(IOError, 'closed stream') unless Thread.current[:cliui_allowed_to_read]
+
+              @stream.send(method, *args, **kwargs, &block)
+            end
+          end
+
+          NON_READING_METHODS.each do |method|
+            define_method(method) do |*args, **kwargs, &block|
+              @stream.send(method, *args, **kwargs, &block)
+            end
+          end
         end
       end
 

--- a/vendor/reentrant_mutex.rb
+++ b/vendor/reentrant_mutex.rb
@@ -1,0 +1,75 @@
+# Copyright (c) 2014 Boris Bera
+#
+# MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Sourced from https://github.com/dotboris/reentrant_mutex
+
+class ReentrantMutex < Mutex
+  def initialize
+    @count_mutex = Mutex.new
+    @counts = Hash.new(0)
+
+    super
+  end
+
+  def synchronize
+    raise ThreadError, 'Must be called with a block' unless block_given?
+
+    begin
+      lock
+      yield
+    ensure
+      unlock
+    end
+  end
+
+  def lock
+    c = increase_count Thread.current
+    super if c <= 1
+  end
+
+  def unlock
+    c = decrease_count Thread.current
+    if c <= 0
+      super
+      delete_count Thread.current
+    end
+  end
+
+  def count
+    @count_mutex.synchronize { @counts[Thread.current] }
+  end
+
+  private
+
+  def increase_count(thread)
+    @count_mutex.synchronize { @counts[thread] += 1 }
+  end
+
+  def decrease_count(thread)
+    @count_mutex.synchronize { @counts[thread] -= 1 }
+  end
+
+  def delete_count(thread)
+    @count_mutex.synchronize { @counts.delete(thread) }
+  end
+end


### PR DESCRIPTION
SpinGroup runs Tasks inside of threads, which previously presented difficulties for handling sources of input. In this change, we have added support for a Mutex that supports reentrance as well as handling global variables in thread variables. This way we can communicate a thread's intent to read input, block other threads from doing so until the input is collected, and move on safely.

Fixes #281