### PR TITLE
Expose `CLI::UI.any_key` convenience method

### DIFF
--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -89,6 +89,17 @@ module CLI
         CLI::UI::Prompt.confirm(question, default: default)
       end
 
+      # Convenience Method for +CLI::UI::Prompt.any_key+
+      #
+      # ==== Attributes
+      #
+      # * +prompt+ - prompt to present
+      #
+      sig { params(prompt: String).returns(T.nilable(String)) }
+      def any_key(prompt = 'Press any key to continue')
+        CLI::UI::Prompt.any_key(prompt)
+      end
+
       # Convenience Method for +CLI::UI::Prompt.ask+
       sig do
         params(


### PR DESCRIPTION
This exposes a convenience method for `CLI::UI::Prompt.any_key` (added in #375), to match the other convenience methods.

No convenience method is added for `CLI::UI::Prompt.read_char`, as it seems low level enough not to warrant it.