### PR TITLE
Remove bolding from non-multiple choice prompts

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -486,8 +486,10 @@ module CLI
             message = "  #{num}#{num ? "." : " "}#{padding}"
 
             format = '%s'
-            # If multiple, bold only selected. If not multiple, bold everything
-            format = "{{bold:#{format}}}" if !@multiple || is_chosen
+            # If multiple, bold selected. If not multiple, do not bold any options.
+            # Bolding options can cause confusion as some users may perceive bold white (default color) as selected
+            # rather than the actual selected color.
+            format = "{{bold:#{format}}}" if @multiple && is_chosen
             format = "{{cyan:#{format}}}" if @multiple && is_chosen && num != @active
             format = " #{format}"
 


### PR DESCRIPTION
## What this does

This changes the Interactive Options from bolding all options to bolding only multiple choice options.

### Old

<img width="491" alt="image" src="https://user-images.githubusercontent.com/3074765/220421112-c726115c-cbbe-4a98-aa9c-86002425d5dd.png">

### New

<img width="478" alt="image" src="https://user-images.githubusercontent.com/3074765/220421020-dbd853af-2fb3-489b-a475-47794b93759a.png">

## Why?

We have been using this library for internal tools and users have been getting confused at which item was the selected one. The boldness of the white text (default color) was causing users to believe the wrong item was selected. This is exasperated by instances where there are 2 options (e.g. yes/no questions).

By making this not-bold, it adds no highlighting to the not-selected option causing users to correctly identify the bright blue / option prefixed by > as the selected option.
