### PR TITLE
Fix a miscalculation in the number of req. lines

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -111,21 +111,27 @@ module CLI
           # so to get the # of lines, you need to join then split
 
           # since lines may be longer than the terminal is wide, we need to
-          # determine how many extra lines would be taken up by them
-          max_width = (@terminal_width_at_calculation_time -
-                       @options.count.to_s.size - # Width of the displayed number
-                       5 -                        # Extra characters added during rendering
-                       (@multiple ? 1 : 0)        # Space for the checkbox, if rendered
-                      ).to_f
+          # determine how many extra lines would be taken up by them.
+          #
+          # To accomplish this we split the string by new lines and add the extra characters to the first line.
+          # Then we calculate how many lines would be needed to render the string based on the terminal width
+          extra_chars = @marker.length +
+            1 + # 1 space
+            @options.count.to_s.size + # Width of the displayed number
+            1 + # .
+            1 + # space after .
+            (@multiple ? 1 : 0) # Space for the checkbox, if rendered
 
           @option_lengths = @options.map do |text|
-            width = 1 if text.empty?
-            width ||= text
-              .split("\n")
-              .reject(&:empty?)
-              .sum { |l| (CLI::UI.fmt(l, enable_color: false).length / max_width).ceil }
-
-            width
+            next 1 if text.empty?
+            
+            # Find the length of all the lines in this string
+            non_empty_line_lengths = text.split("\n").reject(&:empty?).map { |l| CLI::UI.fmt(l, enable_color: false).length }
+            # The first line has the marker and number, so we add that so we can take it into account
+            non_empty_line_lengths[0] += extra_chars
+            # Finally, we need to calculate how many lines each one will take. We can do that by dividing each one
+            # by the width of the terminal, rounding up to the nearest natural number
+            non_empty_line_lengths.sum { |length| (length.to_f / @terminal_width_at_calculation_time).ceil }
           end
         end
 


### PR DESCRIPTION
# What this does

Fixes a miscalculation in the number of lines requires for output.

# The problem

https://user-images.githubusercontent.com/3074765/232186992-9c29f095-f20d-4768-b045-bfcd8df0dac2.mov

We had an issue where interactive options could produce extra lines on small width terminals. For replication steps, follow this:

1. Open a terminal
2. Make it a small width such that `tput cols` is under 50
3. Open a new tab (this is required for some reason, but I didnt dig in)
4. Run this code:
```ruby
require 'cli/ui'

CLI::UI::StdoutRouter.enable

puts CLI::UI::Terminal.width

CLI::UI::Prompt.ask('CHOOSE!') do |handler|
  handler.option('a' * 50)  { |selection| selection }
  handler.option('a' * 60)  { |selection| selection }
  handler.option('a' * 70)  { |selection| selection }
end
```
5. Paginate the options and see it duplicate
This likely fixes https://github.com/Shopify/cli-ui/issues/253 as well

# How does this fix it?

The previous calculation was taking the terminal width and taking 5 characters off. This made it seem like every line was 5 characters shorter when only the first line was.

This fix changes the magic 5 number to be dynamically determined, and then explains where the rest comes from. Then it calculates all the lengths and adds the 5 to the first line only. Using that we can calculate against the raw terminal width