### PR TITLE
📦️ Define ReentrantMutex inside CLI::UI module to avoid conflicts

### DIFF
--- a/lib/cli/ui/stdout_router.rb
+++ b/lib/cli/ui/stdout_router.rb
@@ -92,7 +92,7 @@ module CLI
         extend T::Sig
 
         @capture_mutex = Mutex.new
-        @stdin_mutex = ReentrantMutex.new
+        @stdin_mutex = CLI::UI::ReentrantMutex.new
         @active_captures = 0
         @saved_stdin = nil
 
@@ -262,7 +262,7 @@ module CLI
           sig { params(stream: IO).void }
           def initialize(stream)
             @stream = stream
-            @m = ReentrantMutex.new
+            @m = CLI::UI::ReentrantMutex.new
           end
 
           sig { type_parameters(:T).params(block: T.proc.returns(T.type_parameter(:T))).returns(T.type_parameter(:T)) }


### PR DESCRIPTION
Given that `ReentrantMutex` was defined at the top level, it conflicts with other definitions of the same name like the one the [logging](https://github.com/TwP/logging/blob/b77368369ae7f323c65eebcd8d8c3aca64188925/lib/logging/utils.rb#L146-L169) gem defines.

So, if `cli-ui` is loaded after `logging`, it breaks the `logging` gem (and vice-versa)