### PR TITLE
Fix frames in journald

### DIFF
--- a/lib/cli/ui/frame.rb
+++ b/lib/cli/ui/frame.rb
@@ -261,8 +261,8 @@ module CLI
               final_color = color || item.color
               output << CLI::UI.resolve_color(final_color).code \
                 << item.frame_style.prefix \
-                << ' ' \
-                << CLI::UI::Color::RESET.code
+                << CLI::UI::Color::RESET.code \
+                << ' '
             end
           end
         end

--- a/lib/cli/ui/frame/frame_style/box.rb
+++ b/lib/cli/ui/frame/frame_style/box.rb
@@ -133,7 +133,7 @@ module CLI
               # extra-reliably, so we fall back to a less foolproof strategy. This
               # is probably better in general for cases with impoverished terminal
               # emulators and no active user.
-              unless [0, '', nil].include?(ENV['CI'])
+              unless [0, '', nil].include?(ENV['CI']) && [0, '', nil].include?(ENV['JOURNAL_STREAM'])
                 linewidth = [0, termwidth - (preamble_end + suffix_width + 1)].max
 
                 o << color.code << preamble

--- a/lib/cli/ui/frame/frame_style/bracket.rb
+++ b/lib/cli/ui/frame/frame_style/bracket.rb
@@ -113,7 +113,7 @@ module CLI
               # extra-reliably, so we fall back to a less foolproof strategy. This
               # is probably better in general for cases with impoverished terminal
               # emulators and no active user.
-              unless [0, '', nil].include?(ENV['CI'])
+              unless [0, '', nil].include?(ENV['CI']) && [0, '', nil].include?(ENV['JOURNAL_STREAM'])
                 o << color.code << preamble
                 o << color.code << suffix
                 o << CLI::UI::Color::RESET.code

--- a/test/cli/ui/printer_test.rb
+++ b/test/cli/ui/printer_test.rb
@@ -25,7 +25,7 @@ module CLI
           end
         end
 
-        assert_equal("\e[31m┃ \e[0m\e[0mfoo\n", out)
+        assert_equal("\e[31m┃\e[0m \e[0mfoo\n", out)
       end
 
       def test_frame_with_long_texts
@@ -42,7 +42,7 @@ module CLI
           end
         end
 
-        assert_equal("\e[31m┃ \e[0m\e[0mfoo\n", out)
+        assert_equal("\e[31m┃\e[0m \e[0mfoo\n", out)
       end
 
       def test_puts_stream


### PR DESCRIPTION
journald doesn't handle carriage returns well so we handle it similar to $CI and avoid outputting them when $JOURNAL_STREAM is set. journald also gets tripped up by the broken color codes we were accidentally outputting sometimes when chopping the last character of a frame's prefix so that's been addressed too.

This doesn't fix things like spinners but is still a nice improvement over the current output.

---

running one of the examples in the README.md via `systemd-run -d bundle exec ruby example.rb`:

before:
```
Jul 08 00:10:30 systemd[1]: Started /home/spin/.bundle/cli-ui/bin/bundle exec ruby example.rb.
Jul 08 00:10:34 bundle[37770]: [282B blob data]
Jul 08 00:10:34 bundle[37770]: [287B blob data]
Jul 08 00:10:34 bundle[37770]: [284B blob data]
Jul 08 00:10:34 bundle[37770]: [20B blob data]
Jul 08 00:10:34 bundle[37770]: [26B blob data]
Jul 08 00:10:34 bundle[37770]: [27B blob data]
Jul 08 00:10:34 bundle[37770]: [2.2K blob data]
Jul 08 00:10:34 bundle[37770]: [288B blob data]
Jul 08 00:10:34 bundle[37770]: [284B blob data]
Jul 08 00:10:34 bundle[37770]: ┃ words oh no! success!
Jul 08 00:10:34 bundle[37770]: [21B blob data]
Jul 08 00:10:34 bundle[37770]: [389B blob data]
Jul 08 00:10:34 bundle[37770]: ┃┃ RuntimeError: oh no
Jul 08 00:10:34 bundle[37770]: ┃┃         from example.rb:22:in `block (3 levels) in <main>'
Jul 08 00:10:34 bundle[37770]: ┃┃         from /home/spin/src/github.com/Shopify/cli-ui/lib/cli/ui/spinner/spin_group.rb:111:in `block (2 levels) in initialize'
Jul 08 00:10:34 bundle[37770]: ┃┃         from /home/spin/src/github.com/Shopify/cli-ui/lib/cli/ui/stdout_router.rb:243:in `block in run'
Jul 08 00:10:34 bundle[37770]: ┃┃         from /home/spin/src/github.com/Shopify/cli-ui/lib/cli/ui/stdout_router.rb:167:in `with_stdin_masked'
Jul 08 00:10:34 bundle[37770]: ┃┃         from /home/spin/src/github.com/Shopify/cli-ui/lib/cli/ui/stdout_router.rb:228:in `run'
Jul 08 00:10:34 bundle[37770]: ┃┃         from /home/spin/src/github.com/Shopify/cli-ui/lib/cli/ui/spinner/spin_group.rb:113:in `block in initialize'
Jul 08 00:10:34 bundle[37770]: [287B blob data]
Jul 08 00:10:34 bundle[37770]: ┃┃ (empty)
Jul 08 00:10:34 bundle[37770]: [287B blob data]
Jul 08 00:10:34 bundle[37770]: ┃┃ (empty)
Jul 08 00:10:34 bundle[37770]: [287B blob data]
Jul 08 00:10:34 bundle[37770]: [284B blob data]
Jul 08 00:10:34 systemd[1]: run-u1638.service: Deactivated successfully.
```

after:
```
Jul 08 00:07:41 systemd[1]: Started /home/spin/.bundle/cli-ui/bin/bundle exec ruby example.rb.
Jul 08 00:07:45 bundle[36462]: ┏━━ ⭑ a ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Jul 08 00:07:45 bundle[36462]: ┃┏━━ 𝒾 b ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Jul 08 00:07:45 bundle[36462]: ┃┃┏━━ ? c ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Jul 08 00:07:45 bundle[36462]: [20B blob data]
Jul 08 00:07:45 bundle[36462]: [26B blob data]
Jul 08 00:07:45 bundle[36462]: [27B blob data]
Jul 08 00:07:45 bundle[36462]: [2.1K blob data]
Jul 08 00:07:45 bundle[36462]: ┃┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (3.51s) 
Jul 08 00:07:45 bundle[36462]: ┣━━ ✓ lol ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Jul 08 00:07:45 bundle[36462]: ┃ words oh no! success!
Jul 08 00:07:45 bundle[36462]: [21B blob data]
Jul 08 00:07:45 bundle[36462]: [272B blob data]
Jul 08 00:07:45 bundle[36462]: ┃┃ RuntimeError: oh no
Jul 08 00:07:45 bundle[36462]: ┃┃         from example.rb:22:in `block (3 levels) in <main>'
Jul 08 00:07:45 bundle[36462]: ┃┃         from /home/spin/src/github.com/Shopify/cli-ui/lib/cli/ui/spinner/spin_group.rb:111:in `block (2 levels) in initialize'
Jul 08 00:07:45 bundle[36462]: ┃┃         from /home/spin/src/github.com/Shopify/cli-ui/lib/cli/ui/stdout_router.rb:243:in `block in run'
Jul 08 00:07:45 bundle[36462]: ┃┃         from /home/spin/src/github.com/Shopify/cli-ui/lib/cli/ui/stdout_router.rb:167:in `with_stdin_masked'
Jul 08 00:07:45 bundle[36462]: ┃┃         from /home/spin/src/github.com/Shopify/cli-ui/lib/cli/ui/stdout_router.rb:228:in `run'
Jul 08 00:07:45 bundle[36462]: ┃┃         from /home/spin/src/github.com/Shopify/cli-ui/lib/cli/ui/spinner/spin_group.rb:113:in `block in initialize'
Jul 08 00:07:45 bundle[36462]: ┃┣━━ STDOUT ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Jul 08 00:07:45 bundle[36462]: ┃┃ (empty)
Jul 08 00:07:45 bundle[36462]: ┃┣━━ STDERR ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Jul 08 00:07:45 bundle[36462]: ┃┃ (empty)
Jul 08 00:07:45 bundle[36462]: ┃┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (0.5s) 
Jul 08 00:07:45 bundle[36462]: ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (4.02s) 
Jul 08 00:07:45 systemd[1]: run-u1576.service: Deactivated successfully.
```