### PR TITLE
Improve log output

### DIFF
--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -145,10 +145,11 @@ module CLI
       #
       # * +input+ - input to format
       # * +truncate_to+ - number of characters to truncate the string to (or nil)
+      # * +enable_color+ - should color be used? default to true unless output is redirected.
       #
-      sig { params(input: String, truncate_to: T.nilable(Integer)).returns(String) }
-      def resolve_text(input, truncate_to: nil)
-        formatted = CLI::UI::Formatter.new(input).format
+      sig { params(input: String, truncate_to: T.nilable(Integer), enable_color: T::Boolean).returns(String) }
+      def resolve_text(input, truncate_to: nil, enable_color: enable_color?)
+        formatted = CLI::UI::Formatter.new(input).format(enable_color: enable_color)
         return formatted unless truncate_to
 
         CLI::UI::Truncater.call(formatted, truncate_to)
@@ -329,16 +330,16 @@ module CLI
         Thread.current[:no_cliui_frame_inset] = prev
       end
 
-      # Check whether colour is enabled in Formatter output. By default, colour
-      # is enabled when STDOUT is a TTY; that is, when output has not been
-      # redirected to another program or to a file.
+      # Check whether colour is enabled in Formatter, Frame, and Spinner output.
+      # By default, colour is enabled when STDOUT is a TTY; that is, when output
+      # has not been directed to another program or to a file.
       #
       sig { returns(T::Boolean) }
       def enable_color?
         @enable_color
       end
 
-      # Turn colour output in Formatter on or off.
+      # Turn colour in Formatter, Frame, and Spinner output on or off.
       #
       # ==== Attributes
       #
@@ -347,6 +348,26 @@ module CLI
       sig { params(bool: T::Boolean).void }
       def enable_color=(bool)
         @enable_color = !!bool
+      end
+
+      # Check whether cursor control is enabled in Formatter, Frame, and Spinner output.
+      # By default, cursor control is enabled when STDOUT is a TTY; that is, when output
+      # has not been directed to another program or to a file.
+      #
+      sig { returns(T::Boolean) }
+      def enable_cursor?
+        @enable_cursor
+      end
+
+      # Turn cursor control in Formatter, Frame, and Spinner output on or off.
+      #
+      # ==== Attributes
+      #
+      # * +bool+ - true or false; enable or disable cursor control.
+      #
+      sig { params(bool: T::Boolean).void }
+      def enable_cursor=(bool)
+        @enable_cursor = !!bool
       end
 
       # Set the default frame style.
@@ -375,6 +396,9 @@ module CLI
     end
 
     self.enable_color = $stdout.tty?
+
+    # Shopify's CI system supports color, but not cursor control
+    self.enable_cursor = T.must($stdout.tty? && ENV['CI'].nil? && ENV['JOURNAL_STREAM'].nil?)
   end
 end
 

--- a/lib/cli/ui/frame.rb
+++ b/lib/cli/ui/frame.rb
@@ -254,15 +254,17 @@ module CLI
             items = FrameStack.items
 
             items[0..-2].to_a.each do |item|
-              output << item.color.code << item.frame_style.prefix
+              output << item.color.code if CLI::UI.enable_color?
+              output << item.frame_style.prefix
+              output << CLI::UI::Color::RESET.code if CLI::UI.enable_color?
             end
 
             if (item = items.last)
               final_color = color || item.color
-              output << CLI::UI.resolve_color(final_color).code \
-                << item.frame_style.prefix \
-                << CLI::UI::Color::RESET.code \
-                << ' '
+              output << CLI::UI.resolve_color(final_color).code if CLI::UI.enable_color?
+              output << item.frame_style.prefix
+              output << CLI::UI::Color::RESET.code if CLI::UI.enable_color?
+              output << ' '
             end
           end
         end

--- a/lib/cli/ui/frame/frame_style/box.rb
+++ b/lib/cli/ui/frame/frame_style/box.rb
@@ -94,7 +94,8 @@ module CLI
 
               preamble = +''
 
-              preamble << color.code << first << (HORIZONTAL * 2)
+              preamble << color.code if CLI::UI.enable_color?
+              preamble << first << (HORIZONTAL * 2)
 
               unless text.empty?
                 preamble << ' ' << CLI::UI.resolve_text("{{#{color.name}:#{text}}}") << ' '
@@ -128,18 +129,17 @@ module CLI
 
               o = +''
 
-              # Shopify's CI system supports terminal emulation, but not some of
-              # the fancier features that we normally use to draw frames
-              # extra-reliably, so we fall back to a less foolproof strategy. This
-              # is probably better in general for cases with impoverished terminal
-              # emulators and no active user.
-              unless [0, '', nil].include?(ENV['CI']) && [0, '', nil].include?(ENV['JOURNAL_STREAM'])
+              unless CLI::UI.enable_cursor?
                 linewidth = [0, termwidth - (preamble_end + suffix_width + 1)].max
 
-                o << color.code << preamble
-                o << color.code << (HORIZONTAL * linewidth)
-                o << color.code << suffix
-                o << CLI::UI::Color::RESET.code << "\n"
+                o << color.code if CLI::UI.enable_color?
+                o << preamble
+                o << color.code if CLI::UI.enable_color?
+                o << (HORIZONTAL * linewidth)
+                o << color.code if CLI::UI.enable_color?
+                o << suffix
+                o << CLI::UI::Color::RESET.code if CLI::UI.enable_color?
+                o << "\n"
                 return o
               end
 
@@ -158,12 +158,12 @@ module CLI
               # |                 |                    |            | |
               # V                 V                    V            V V
               # --- Preamble text --------------------- suffix text --
-              o << color.code
+              o << color.code if CLI::UI.enable_color?
               o << print_at_x(preamble_start, HORIZONTAL * (termwidth - preamble_start)) # draw a full line
               o << print_at_x(preamble_start, preamble)
-              o << color.code
+              o << color.code if CLI::UI.enable_color?
               o << print_at_x(suffix_start, suffix)
-              o << CLI::UI::Color::RESET.code
+              o << CLI::UI::Color::RESET.code if CLI::UI.enable_color?
               o << CLI::UI::ANSI.show_cursor
               o << "\n"
 

--- a/lib/cli/ui/frame/frame_style/bracket.rb
+++ b/lib/cli/ui/frame/frame_style/bracket.rb
@@ -94,7 +94,8 @@ module CLI
 
               preamble = +''
 
-              preamble << color.code << first << (HORIZONTAL * 2)
+              preamble << color.code if CLI::UI.enable_color?
+              preamble << first << (HORIZONTAL * 2)
 
               unless text.empty?
                 preamble << ' ' << CLI::UI.resolve_text("{{#{color.name}:#{text}}}") << ' '
@@ -108,15 +109,12 @@ module CLI
 
               o = +''
 
-              # Shopify's CI system supports terminal emulation, but not some of
-              # the fancier features that we normally use to draw frames
-              # extra-reliably, so we fall back to a less foolproof strategy. This
-              # is probably better in general for cases with impoverished terminal
-              # emulators and no active user.
-              unless [0, '', nil].include?(ENV['CI']) && [0, '', nil].include?(ENV['JOURNAL_STREAM'])
-                o << color.code << preamble
-                o << color.code << suffix
-                o << CLI::UI::Color::RESET.code
+              unless CLI::UI.enable_cursor?
+                o << color.code if CLI::UI.enable_color?
+                o << preamble
+                o << color.code if CLI::UI.enable_color?
+                o << suffix
+                o << CLI::UI::Color::RESET.code if CLI::UI.enable_color?
                 o << "\n"
 
                 return o
@@ -134,9 +132,11 @@ module CLI
               # reset to column 1 so that things like ^C don't ruin formatting
               o << "\r"
 
-              o << color.code
-              o << print_at_x(preamble_start, preamble + color.code + suffix)
-              o << CLI::UI::Color::RESET.code
+              o << color.code if CLI::UI.enable_color?
+              o << print_at_x(preamble_start, preamble)
+              o << color.code if CLI::UI.enable_color?
+              o << suffix
+              o << CLI::UI::Color::RESET.code if CLI::UI.enable_color?
               o << CLI::UI::ANSI.show_cursor
               o << "\n"
 

--- a/lib/cli/ui/spinner.rb
+++ b/lib/cli/ui/spinner.rb
@@ -22,7 +22,7 @@ module CLI
 
       colors = [CLI::UI::Color::CYAN.code] * (RUNES.size / 2).ceil +
         [CLI::UI::Color::MAGENTA.code] * (RUNES.size / 2).to_i
-      GLYPHS = colors.zip(RUNES).map(&:join)
+      GLYPHS = colors.zip(RUNES).map { |c, r| c + r + CLI::UI::Color::RESET.code }.freeze
 
       class << self
         extend T::Sig

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require 'cli/ui'
 
 # Otherwise, results will vary depending on the context in which we run tests.
 CLI::UI.enable_color = true
+CLI::UI.enable_cursor = true
 
 module CLI
   module UI


### PR DESCRIPTION
This applies `CLI::UI.enable_color?` to Frame and Spinner output, and adds `CLI::UI.enable_cursor?` to disable cursor control when it's not supported.

I considered adding these as a parameters to Frame and Spinner, but it ended up bloating the code for little tangible benefit as these settings are usually static for the lifetime of the program. If we wanted to support something like that, I think the best approach would be to bundle color + cursor control settings along with `IOLike` as a sort of printing context. Nothing here prevents us from doing that in the future if the need arises.

---

for comparison here's the output of one of the examples from the README piped into `less`

before:

![image](https://github.com/Shopify/cli-ui/assets/100245234/3cd779b0-41b9-469a-9a7c-06ba9097c224)


after:

![image](https://github.com/Shopify/cli-ui/assets/100245234/0cfc984b-f566-4cdd-a7d2-0fc680754de9)
