### PR TITLE
Allow default without multiple choices

### DIFF
--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -137,10 +137,6 @@ module CLI
           &options_proc
         )
           has_options = !!(options || block_given?)
-          if has_options && default && !multiple
-            raise(ArgumentError, 'conflicting arguments: default may not be provided with options when not multiple')
-          end
-
           if has_options && is_file
             raise(ArgumentError, 'conflicting arguments: is_file is only useful when options are not provided')
           end

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -59,7 +59,11 @@ module CLI
         end
         def initialize(options, multiple: false, default: nil)
           @options = options
-          @active = 1
+          @active = if default && (i = options.index(default))
+            i + 1
+          else
+            1
+          end
           @marker = '>'
           @answer = nil
           @state = :root

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -155,9 +155,6 @@ module CLI
       end
 
       def test_ask_invalid_kwargs
-        error = assert_raises(ArgumentError) { Prompt.ask('q', options: ['a'], default: 'a') }
-        assert_equal('conflicting arguments: default may not be provided with options when not multiple', error.message)
-
         error = assert_raises(ArgumentError) { Prompt.ask('q', options: ['a'], is_file: true) }
         assert_equal('conflicting arguments: is_file is only useful when options are not provided', error.message)
 
@@ -169,7 +166,7 @@ module CLI
         error = assert_raises(ArgumentError) do
           Prompt.ask('q', default: 'b') {}
         end
-        assert_equal('conflicting arguments: default may not be provided with options when not multiple', error.message)
+        assert_equal('insufficient options', error.message)
       end
 
       def test_ask_interactive_conflicting_arguments
@@ -280,6 +277,14 @@ module CLI
         )
         write('120')
         assert_output_includes(['1', '3'].inspect)
+      end
+
+      def test_ask_with_default_values
+        run_in_process(
+          'puts CLI::UI::Prompt.ask("q", options: (1..15).map(&:to_s), default: \'2\').inspect',
+        )
+        write("\n")
+        assert_output_includes('You chose: 2')
       end
 
       def test_ask_instructions_color


### PR DESCRIPTION
I've got a long list I want someone to choose one item from, but there's already a selected element. That element might be number 50 in a list (and often what the user wants is a nearby option). So instead of starting at the top every time and scrolling, allow default to be used to set the `active` element in a prompt and if a user just presses enter, they keep the element that was previously selected.