### PR TITLE
Drop ruby 2.7 from CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        ruby-version: ['2.7', '3.0']
+        ruby-version: ['3.0', '3.1', '3.2']
 
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
`rubocop-sorbet` now requires ruby 3+