### PR TITLE
Replace `Readline` with `reline`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.1', '3.2', '3.3']
 
     runs-on: ${{ matrix.os }}
     env:

--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 up:
-  - homebrew:
+  - packages:
     - fswatch
-  - ruby: 3.1.2
+  - ruby: 3.3.0
   - bundler
 
 commands:

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -3,21 +3,11 @@
 # typed: true
 
 require 'cli/ui'
-require 'readline'
-
-module Readline
-  unless const_defined?(:FILENAME_COMPLETION_PROC)
-    FILENAME_COMPLETION_PROC = proc do |input|
-      directory = input[-1] == '/' ? input : File.dirname(input)
-      filename = input[-1] == '/' ? '' : File.basename(input)
-
-      (Dir.entries(directory).select do |fp|
-        fp.start_with?(filename)
-      end - (input[-1] == '.' ? [] : ['.', '..'])).map do |fp|
-        File.join(directory, fp).gsub(/\A\.\//, '')
-      end
-    end
-  end
+begin
+  require 'reline' # For 2.7+
+rescue LoadError
+  require 'readline' # For 2.6
+  Object.const_set(:Reline, Readline)
 end
 
 module CLI
@@ -375,11 +365,20 @@ module CLI
         sig { params(is_file: T::Boolean).returns(String) }
         def readline(is_file: false)
           if is_file
-            Readline.completion_proc = Readline::FILENAME_COMPLETION_PROC
-            Readline.completion_append_character = ''
+            Reline.completion_proc = proc do |input|
+              directory = input[-1] == '/' ? input : File.dirname(input)
+              filename = input[-1] == '/' ? '' : File.basename(input)
+
+              (Dir.entries(directory).select do |fp|
+                fp.start_with?(filename)
+              end - (input[-1] == '.' ? [] : ['.', '..'])).map do |fp|
+                File.join(directory, fp).gsub(/\A\.\//, '')
+              end
+            end
+            Reline.completion_append_character = ''
           else
-            Readline.completion_proc = proc { |*| nil }
-            Readline.completion_append_character = ' '
+            Reline.completion_proc = proc { |*| nil }
+            Reline.completion_append_character = ' '
           end
 
           # because Readline is a C library, CLI::UI's hooks into $stdout don't
@@ -393,7 +392,7 @@ module CLI
           prompt += CLI::UI::Color::YELLOW.code if CLI::UI::OS.current.use_color_prompt?
 
           begin
-            line = Readline.readline(prompt, true)
+            line = Reline.readline(prompt, true)
             print(CLI::UI::Color::RESET.code)
             line.to_s.chomp
           rescue Interrupt


### PR DESCRIPTION
`reline` was [added to the standard library in 2.7](https://rubyreferences.github.io/rubychanges/2.7.html#standard-library-contents-change), in December 2019.

`readline` was [removed from the standard library in 3.3](https://bugs.ruby-lang.org/issues/19616).