### PR TITLE
Add ability to set title for progress bars

### DIFF
--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -187,7 +187,18 @@ module CLI
         #
         sig { returns(String) }
         def previous_line
-          cursor_up + cursor_horizontal_absolute
+          previous_lines(1)
+        end
+
+        # Move to the previous n lines
+        #
+        # ==== Attributes
+        #
+        # * +n+ - number of lines by which to move the cursor up
+        #
+        sig { params(n: Integer).returns(String) }
+        def previous_lines(n = 1)
+          cursor_up(n) + cursor_horizontal_absolute
         end
 
         sig { returns(String) }


### PR DESCRIPTION
We recently used progress bar for a quite long running task. And while having % printed is good, it was not enough. 
We had a lot if items processed inside the progress bar and using spinners, for example, which already have an ability to use titles, would be messy. It will be useful to have some additional dynamically updatable title that indicates the currently running task inside the progress bar itself.

And so this PR adds an ability to set such a title. Usage example:
```ruby
CLI::UI::Progress.progress do |bar|
  items.each do |item|
    bar.update_title("#{item.name}")
    bar.tick
  end
end
```