### PR TITLE
Strip OSC sequences

### DIFF
--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -45,7 +45,7 @@ module CLI
         #
         sig { params(str: String).returns(String) }
         def strip_codes(str)
-          str.gsub(/\x1b\[[\d;]+[A-Za-z]|\r/, '')
+          str.gsub(/\x1b\[[\d;]+[A-Za-z]|\x1b\][\d;]+.*?\x1b\\|\r/, '')
         end
 
         # Returns an ANSI control sequence

--- a/test/cli/ui/ansi_test.rb
+++ b/test/cli/ui/ansi_test.rb
@@ -15,6 +15,8 @@ module CLI
 
         assert_equal(3, ANSI.printing_width('>🔧<'))
         assert_equal(1, ANSI.printing_width('👩‍💻'))
+
+        assert_equal(4, ANSI.printing_width(UI.link('url', 'text')))
       end
 
       def test_line_skip_with_shift


### PR DESCRIPTION
This makes it possible to compute the width of text that contains hyperlinks. We currently only strip OSC sequences that end in ST. Sometimes OSC sequences can end in BEL, but this is apparently non-standard. We can support it in the future if the need arises.