### PR TITLE
Fix running spinners inside prompt callbacks

### DIFF
--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -300,6 +300,8 @@ module CLI
           instructions += ", filter with 'f'" if filter_ui
           instructions += ", enter option with 'e'" if select_ui && (options.size > 9)
 
+          resp = nil
+
           CLI::UI::StdoutRouter::Capture.in_alternate_screen do
             puts_question("#{question} " + instructions_color.code + "(#{instructions})" + Color::RESET.code)
             resp = interactive_prompt(options, multiple: multiple, default: default)
@@ -324,12 +326,12 @@ module CLI
               resp
             end
             puts_question("#{question} (You chose: {{italic:#{resp_text}}})")
+          end
 
-            if block_given?
-              T.must(handler).call(resp)
-            else
-              resp
-            end
+          if block_given?
+            T.must(handler).call(resp)
+          else
+            resp
           end
         end
 

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -321,6 +321,21 @@ module CLI
         assert_output_includes('c'.inspect)
       end
 
+      def test_spinner_inside_prompt
+        run_in_process(<<~RUBY)
+          CLI::UI::Prompt.ask('question') do |handler|
+            handler.option('option') do
+              CLI::UI::Spinner.spin('spinner') do
+                puts 'spinner'
+              end
+            end
+          end
+        RUBY
+
+        write("option\n")
+        assert_output_includes('spinner')
+      end
+
       private
 
       def run_in_process(code)


### PR DESCRIPTION
Fixes #500.

Regression was introduced in #380 (cc @arcadia-rose @lugray).

It was hanging, because it was in the infinite loop https://github.com/Shopify/cli-ui/blob/11302d0108e9e08df47c9e29e10e9896cfa52833/lib/cli/ui/spinner/spin_group.rb#L307-L313