### PR TITLE
Introduces a width parameter to CLI::UI::Wrap

### DIFF
--- a/lib/cli/ui/wrap.rb
+++ b/lib/cli/ui/wrap.rb
@@ -16,9 +16,9 @@ module CLI
         @input = input
       end
 
-      sig { returns(String) }
-      def wrap
-        max_width = Terminal.width - Frame.prefix_width
+      sig { params(total_width: Integer).returns(String) }
+      def wrap(total_width = Terminal.width)
+        max_width = total_width - Frame.prefix_width
         width = T.let(0, Integer)
         final = []
         # Create an alternation of format codes of parameter lengths 1-20, since + and {1,n} not allowed in lookbehind

--- a/test/cli/ui/wrap_test.rb
+++ b/test/cli/ui/wrap_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+module CLI
+  module UI
+    class WrapTest < Minitest::Test
+      def test_wrap
+        para = 'Voluptatem consequatur ipsum. Totam omnis corrupti. Dignissimos esse repudiandae.'
+        w = Wrap.new(para)
+
+        ex = w.wrap(20)
+
+        Terminal.stubs(:width).returns(20)
+        assert_equal(ex, w.wrap)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need to be able to apply .wrap to arbitrary widths in subshells where the terminal width isn't necessarily the final width of the display area.