### PR TITLE
Add SpinGroup.puts_above

### DIFF
--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -206,6 +206,16 @@ module CLI
         def clear_to_end_of_line
           control('', 'K')
         end
+
+        sig { returns(String) }
+        def insert_line
+          insert_lines(1)
+        end
+
+        sig { params(n: Integer).returns(String) }
+        def insert_lines(n = 1)
+          control(n.to_s, 'L')
+        end
       end
     end
   end


### PR DESCRIPTION
This is useful for things like printing out a stream of logs while you have one or more spinners reporting on the current status. We could also add Spinner.puts_above, but when you have multiple Spinners, "above" is kind of ambiguous. We can add it later if the need becomes obvious.