### PR TITLE
Add support to stop SpinGroup and show interrupt debrief

### DIFF
--- a/test/cli/ui/spinner/spin_group_test.rb
+++ b/test/cli/ui/spinner/spin_group_test.rb
@@ -135,7 +135,7 @@ module CLI
 
             sg.add('Interruptible task') do
               started_queue.push(true)
-              10.times { sleep(0.1) }
+              sleep(1)
               task_completed = true
             rescue Interrupt
               task_interrupted = true
@@ -143,6 +143,7 @@ module CLI
             end
 
             t = Thread.new { sg.wait }
+            t.report_on_exception = false
 
             # Wait for task to start
             started_queue.pop
@@ -153,6 +154,155 @@ module CLI
             assert_raises(Interrupt) { t.join }
             refute(task_completed, 'Task should not have completed')
             assert(task_interrupted, 'Task should have been interrupted')
+          end
+        end
+
+        def test_spin_group_stop
+          capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+            sg = SpinGroup.new
+
+            task_started = false
+            task_completed = false
+
+            sg.add('Stoppable task') do
+              task_started = true
+              sleep(1)
+              task_completed = true
+            end
+
+            t = Thread.new { sg.wait }
+
+            # Wait for task to start
+            sleep(0.1) until task_started
+
+            # Stop the spin group
+            sg.stop
+
+            t.join
+
+            refute(task_completed, 'Task should not complete after stop')
+            assert(sg.stopped?, 'SpinGroup should be marked as stopped')
+            refute(sg.all_succeeded?, 'Tasks should not be marked as succeeded after stop')
+          end
+        end
+
+        def test_spin_group_nested_stop
+          capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+            sg = SpinGroup.new
+
+            sg.add('Outer task') do
+              sg.stop
+              true
+            end
+
+            refute(sg.wait, 'SpinGroup#wait should return false when stopped')
+            assert(sg.stopped?, 'SpinGroup should be marked as stopped')
+          end
+        end
+
+        def test_spin_group_interrupt_with_debrief
+          capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+            sg = SpinGroup.new(interrupt_debrief: true)
+            task_interrupted = false
+            debrief_called = false
+
+            # Use Queue for thread-safe signaling
+            started_queue = Queue.new
+
+            sg.failure_debrief do |title, _exception, _out, _err|
+              assert_equal('Failed task', title)
+              debrief_called = true
+            end
+
+            sg.add('Failed task') do
+              TASK_FAILED
+            end
+
+            sg.add('Interruptible task') do
+              started_queue.push(true)
+              sleep(1)
+            rescue Interrupt
+              task_interrupted = true
+              raise
+            end
+
+            t = Thread.new { sg.wait }
+            t.report_on_exception = false
+
+            # Wait for task to start
+            started_queue.pop
+            sleep(0.1) # Small delay to ensure we're in sleep
+            t.raise(Interrupt)
+
+            # The interrupt should propagate since we didn't stop
+            assert_raises(Interrupt) { t.join }
+            assert(task_interrupted, 'Task should have been interrupted')
+            assert(debrief_called, 'Debrief should have been called')
+          end
+        end
+
+        def test_spin_group_interrupt_without_debrief
+          capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+            sg = SpinGroup.new(interrupt_debrief: false)
+
+            # Use Queue for thread-safe signaling
+            started_queue = Queue.new
+
+            debrief_called = false
+            sg.failure_debrief do
+              debrief_called = true
+            end
+
+            sg.add('Failed task') do
+              TASK_FAILED
+            end
+            sg.add('Interruptible task') do
+              started_queue.push(true)
+              sleep(1)
+              false
+            end
+
+            t = Thread.new { sg.wait }
+            t.report_on_exception = false
+
+            # Wait for task to actually start
+            started_queue.pop
+            sleep(0.1) # Small delay to ensure we're in sleep
+
+            # Interrupt should be raised through
+            t.raise(Interrupt)
+            assert_raises(Interrupt) { t.join }
+
+            refute(debrief_called, 'failure_debrief should not be called when interrupt_debrief is false')
+          end
+        end
+
+        def test_task_on_done_callback
+          capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+            sg = SpinGroup.new
+
+            callback_executed = false
+            task_completed = false
+
+            sg.add('Task with callback') do |task|
+              task.on_done do |completed_task|
+                callback_executed = true
+                assert_equal('Task with callback', completed_task.title)
+                assert(completed_task.done)
+                assert(completed_task.success)
+              end
+              task_completed = true
+              true
+            end
+
+            assert(sg.wait)
+            assert(task_completed, 'Task should have completed')
+            assert(callback_executed, 'on_done callback should have been executed')
           end
         end
       end


### PR DESCRIPTION
This change adds new capabilities to `SpinGroup`:
- `interrupt_debrief`: This option, specified when initializing the `SpinGroup`, displays the debrief when the `SpinGroup` is interrupted. This is useful to interrupt and see an error without waiting for all tasks to complete.
- `SpinGroup#stop`, `SpinGroup#stopped?`: Programmatic support for stopping a `SpinGroup`. Exposing this method allows a `SpinGroup` to be stopped when a task fails, which can be used to implement fail-fast behavior.
- `SpinGroup::Task#on_done`: Support for a callback executed when a task transitions to done. This can be used to take action based on success or failure, and again can be used as part of an implementation of fail-fast behavior.

The "primitives" above are implemented instead of a specific "fail-fast" option because they provide more flexibility. 

The `#on_done` callback is specified on the `Task` because it also provides more flexibility. With this approach, each task gets its own callback and additional state may be captured in the closure specified, whereas a callback on the `SpinGroup` would be shared across all tasks and, even if it received the task as an argument, it would only have access to the current state of the task.