### PR TITLE
Surface exceptions from tasks

### DIFF
--- a/lib/cli/ui/spinner/spin_group.rb
+++ b/lib/cli/ui/spinner/spin_group.rb
@@ -475,6 +475,13 @@ module CLI
           end
         end
 
+        sig { returns(T::Array[Exception]) }
+        def all_exceptions
+          @m.synchronize do
+            @tasks.filter_map(&:exception)
+          end
+        end
+
         # Debriefs failed tasks is +auto_debrief+ is true
         #
         sig { returns(T::Boolean) }

--- a/test/cli/ui/spinner/spin_group_test.rb
+++ b/test/cli/ui/spinner/spin_group_test.rb
@@ -157,6 +157,26 @@ module CLI
           end
         end
 
+        def test_spin_group_exceptions
+          capture_io do
+            CLI::UI::StdoutRouter.ensure_activated
+            sg = SpinGroup.new
+
+            sg.add('Just a task') do
+            end
+
+            sg.add('Raising task') do
+              raise 'Error'
+            end
+
+            t = Thread.new { sg.wait }
+
+            t.join
+
+            assert_equal(['Error'], sg.all_exceptions.map(&:message))
+          end
+        end
+
         def test_spin_group_stop
           capture_io do
             CLI::UI::StdoutRouter.ensure_activated


### PR DESCRIPTION
I want to bubble up and show exceptions happening in the individual tasks

Alternatively I tried to achieve the same by raising the exception as part of `on_done` of the task, but then I think everything interrupted abruptly and even the failing glyph doesn't appear for the task.