### PR TITLE
Don't enable color or cursor with TERM=dumb

### DIFF
--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -404,10 +404,10 @@ module CLI
       end
     end
 
-    self.enable_color = $stdout.tty?
+    self.enable_color = T.must($stdout.tty? && ENV['TERM'] != 'dumb')
 
     # Shopify's CI system supports color, but not cursor control
-    self.enable_cursor = T.must($stdout.tty? && ENV['CI'].nil? && ENV['JOURNAL_STREAM'].nil?)
+    self.enable_cursor = T.must($stdout.tty? && ENV['TERM'] != 'dumb' && ENV['CI'].nil? && ENV['JOURNAL_STREAM'].nil?)
   end
 end
 


### PR DESCRIPTION
This is causing me problems with MacVim but it's a general rule that if `TERM=dumb`, color escape codes and cursor handling are not supported, so we shouldn't be emitting them.