### PR TITLE
Add support to enter select mode when user has 10+ opts

### DIFF
--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -237,7 +237,6 @@ module CLI
             start_line_select
             @active = n
           else
-       
             @active = n
             @answer = n
           end

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -247,16 +247,14 @@ module CLI
         sig { params(n: Integer).returns(T::Boolean) }
         def should_enter_select_mode?(n)
           # If we have less than 10 options, we don't need to enter select mode
-          # and we can just select the option directly
+          # and we can just select the option directly. This just keeps the code easier
+          # by making the cases simpler to understand
           return false if @options.length <= 9
 
-          # If we have 1 and more than 9, we always need to enter select mode as the user
-          # may want to select 10-19
-          return true if n == 1
-
-          # Otherwise we need to check if we have the range of options needed
-          # for a given `n` (e.g. 2 would require 20+ options, etc).
-          # This can be simplified to >= `n * 10` (e.g. 2 => 20, 3 => 30, etc)
+          # At this point we have 10+ options so always need to check if we should run.
+          # This can be simplified to checking if the length of options is >= to the option selected * 10:
+          # n == 1 && options.length >= 10 (1 * 10), n == 2 && options.length >= 20 (2 * 10), etc.
+          # which can be further simplified to just:
           @options.length >= (n * 10)
         end
 

--- a/lib/cli/ui/prompt/interactive_options.rb
+++ b/lib/cli/ui/prompt/interactive_options.rb
@@ -230,11 +230,34 @@ module CLI
             end
           elsif n == 0
             # Ignore pressing "0" when not in multiple mode
+          elsif should_enter_select_mode?(n)
+            # When we have more than 9 options, we need to enter select mode
+            # to avoid pre-selecting (e.g) 1 when the user wanted 10.
+            # This also applies to 2 and 20+ options, 3/30+, etc.
+            start_line_select
+            @active = n
           else
+       
             @active = n
             @answer = n
           end
           @redraw = true
+        end
+
+        sig { params(n: Integer).returns(T::Boolean) }
+        def should_enter_select_mode?(n)
+          # If we have less than 10 options, we don't need to enter select mode
+          # and we can just select the option directly
+          return false if @options.length <= 9
+
+          # If we have 1 and more than 9, we always need to enter select mode as the user
+          # may want to select 10-19
+          return true if n == 1
+
+          # Otherwise we need to check if we have the range of options needed
+          # for a given `n` (e.g. 2 would require 20+ options, etc).
+          # This can be simplified to >= `n * 10` (e.g. 2 => 20, 3 => 30, etc)
+          @options.length >= (n * 10)
         end
 
         sig { params(char: String).void }

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -9,6 +9,34 @@ require 'open3'
 module CLI
   module UI
     class PromptTest < Minitest::Test
+      def test_interactive_options_with_more_than_9_options_enters_select_mode
+        run_in_process(<<~RUBY)
+          options = ("a".."j").to_a
+          CLI::UI::Prompt.ask('question', options: options)
+        RUBY
+
+        write('1')
+        wait_for_output_to_include('Select: 1')
+      end
+
+      def test_interactive_options_with_more_than_19_options_enters_select_mode
+        run_in_process(<<~RUBY)
+          options = ("a".."t").to_a
+          CLI::UI::Prompt.ask('question', options: options)
+        RUBY
+
+        write('2')
+        wait_for_output_to_include('Select: 2')
+      end
+
+      def test_interactive_options_with_more_than_9_options_doesnt_enter_select_mode_when_not_needed
+        run_in_process(<<~RUBY)
+          CLI::UI::Prompt.ask('question', options: (1..15).map(&:to_s))
+        RUBY
+        write('2')
+        assert_output_includes('You chose: 2')
+      end
+
       # ^C is not handled; raises Interrupt, which may be handled by caller.
       def test_confirm_sigint
         jruby_skip('SIGINT shuts down the JVM instead of raising Interrupt')


### PR DESCRIPTION
## The Problem

I have a user that brought up a concern around the automatic selection of an option when `1` is selected but there are 10+ options. The user expected to enter a select mode so they could enter 10, but it automatically selected option 1. Unfortunately this started a deletion of their branch (as the select prompt was to select a branch to delete), which the user was surprised by.

https://github.com/user-attachments/assets/0ca2f2c9-2ce2-40c0-b13e-f391a59aa99f


## Solution

This PR is proposing to enter the _select mode_ when the user selects `1` and there are 10+ options (2 when there are 20+, etc).

https://github.com/user-attachments/assets/4df6d2ca-56fc-4164-9ec4-eb1a3bf13ac4

This is anticipated to make the select option a little bit safer, though does introduce some (albeit minor) inconsistency by not auto-selecting. The benefit, however, is that we can now better support options 10+! I also doubt that _most_ prompts actually have 10+ options unless choosing from a big list, and so this may be preferable anyways.

