### PR TITLE
fix missing color from list of available colors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cli-ui (2.3.0)
+    cli-ui (2.3.1)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +14,6 @@ GEM
     docile (1.4.0)
     erubi (1.13.0)
     json (2.9.1)
-    json (2.9.1-java)
     language_server-protocol (3.17.0.4)
     method_source (1.1.0)
     minitest (5.25.4)
@@ -32,7 +31,6 @@ GEM
       racc
     prism (1.2.0)
     racc (1.8.1)
-    racc (1.8.1-java)
     rainbow (3.1.1)
     rake (13.2.1)
     rbi (0.2.1)
@@ -68,7 +66,6 @@ GEM
     sorbet (0.5.11781)
       sorbet-static (= 0.5.11781)
     sorbet-runtime (0.5.11781)
-    sorbet-static (0.5.11781-java)
     sorbet-static (0.5.11781-universal-darwin)
     sorbet-static (0.5.11781-x86_64-linux)
     sorbet-static-and-runtime (0.5.11781)

--- a/lib/cli/ui/color.rb
+++ b/lib/cli/ui/color.rb
@@ -56,6 +56,7 @@ module CLI
         reset: RESET,
         bold: BOLD,
         gray: GRAY,
+        orange: ORANGE,
       }.freeze
 
       class InvalidColorName < ArgumentError

--- a/lib/cli/ui/formatter.rb
+++ b/lib/cli/ui/formatter.rb
@@ -24,6 +24,7 @@ module CLI
         'magenta' => '35',
         'cyan' => '36',
         'gray' => '38;5;244',
+        'orange' => '38;5;214',
         'white' => '97',
         'bold' => '1',
         'italic' => '3',

--- a/test/cli/ui/color_test.rb
+++ b/test/cli/ui/color_test.rb
@@ -15,12 +15,14 @@ module CLI
         assert_equal("\x1b[0m",  Color::RESET.code)
         assert_equal("\x1b[1m",  Color::BOLD.code)
         assert_equal("\x1b[97m", Color::WHITE.code)
+        assert_equal("\x1b[38;5;214m", Color::ORANGE.code)
 
         assert_equal('36',  Color::CYAN.sgr)
         assert_equal(:bold, Color::BOLD.name)
 
         assert_equal(Color::BLUE, Color.lookup(:blue))
         assert_equal(Color::RESET, Color.lookup(:reset))
+        assert_equal(Color::ORANGE, Color.lookup(:orange))
 
         assert_raises(Color::InvalidColorName) do
           Color.lookup(:foobar)

--- a/test/cli/ui/color_test.rb
+++ b/test/cli/ui/color_test.rb
@@ -15,17 +15,27 @@ module CLI
         assert_equal("\x1b[0m",  Color::RESET.code)
         assert_equal("\x1b[1m",  Color::BOLD.code)
         assert_equal("\x1b[97m", Color::WHITE.code)
+        assert_equal("\x1b[38;5;244m", Color::GRAY.code)
         assert_equal("\x1b[38;5;214m", Color::ORANGE.code)
 
         assert_equal('36',  Color::CYAN.sgr)
         assert_equal(:bold, Color::BOLD.name)
 
-        assert_equal(Color::BLUE, Color.lookup(:blue))
-        assert_equal(Color::RESET, Color.lookup(:reset))
-        assert_equal(Color::ORANGE, Color.lookup(:orange))
-
         assert_raises(Color::InvalidColorName) do
           Color.lookup(:foobar)
+        end
+      end
+
+      def test_all_colors_lookup
+        Color.available.each do |color_name|
+          # rubocop:disable Sorbet/ConstantsFromStrings
+          color_constant = Color.const_get(color_name.to_s.upcase)
+          # rubocop:enable Sorbet/ConstantsFromStrings
+          lookup_result = Color.lookup(color_name)
+
+          assert_equal(color_constant, lookup_result, "Color lookup failed for #{color_name}")
+          assert_equal(color_name, lookup_result.name, "Color name mismatch for #{color_name}")
+          assert_instance_of(Color, lookup_result, "Lookup result is not a Color instance for #{color_name}")
         end
       end
 

--- a/test/cli/ui/formatter_test.rb
+++ b/test/cli/ui/formatter_test.rb
@@ -77,20 +77,15 @@ module CLI
         assert_equal(expected, actual)
       end
 
-      def test_orange_formatter
-        input = 'a{{orange:this is orange text}}b'
-        expected = "\e[0ma\e[0;38;5;214mthis is orange text\e[0mb"
+      def test_formatter_with_all_colors
+        CLI::UI::Color.available.each do |color_name|
+          input = "test {{#{color_name}:this is #{color_name} text}}"
+          color = CLI::UI::Color.lookup(color_name)
+          expected = "\e[0mtest \e[0;#{color.sgr}mthis is #{color_name} text\e[0m"
 
-        actual = CLI::UI::Formatter.new(input).format
-        assert_equal(expected, actual)
-      end
-
-      def test_orange_formatter_with_glyph
-        input = '{{H}} this is orange text with a glyph'
-        expected = "\e[0;38;5;214m⧖\e[0m this is orange text with a glyph"
-
-        actual = CLI::UI::Formatter.new(input).format
-        assert_equal(expected, actual)
+          actual = CLI::UI::Formatter.new(input).format
+          assert_equal(expected, actual, "Color #{color_name} did not format correctly")
+        end
       end
     end
   end

--- a/test/cli/ui/formatter_test.rb
+++ b/test/cli/ui/formatter_test.rb
@@ -76,6 +76,22 @@ module CLI
         actual = CLI::UI::Formatter.new(input).format
         assert_equal(expected, actual)
       end
+
+      def test_orange_formatter
+        input = 'a{{orange:this is orange text}}b'
+        expected = "\e[0ma\e[0;38;5;214mthis is orange text\e[0mb"
+
+        actual = CLI::UI::Formatter.new(input).format
+        assert_equal(expected, actual)
+      end
+
+      def test_orange_formatter_with_glyph
+        input = '{{H}} this is orange text with a glyph'
+        expected = "\e[0;38;5;214m⧖\e[0m this is orange text with a glyph"
+
+        actual = CLI::UI::Formatter.new(input).format
+        assert_equal(expected, actual)
+      end
     end
   end
 end

--- a/test/cli/ui/glyph_test.rb
+++ b/test/cli/ui/glyph_test.rb
@@ -13,18 +13,8 @@ module CLI
         assert_equal("\x1b[31m✗\x1b[0m", Glyph::X.to_s)
         assert_equal("\x1b[97m🐛\x1b[0m", Glyph::BUG.to_s)
         assert_equal("\x1b[33m»\x1b[0m", Glyph::CHEVRON.to_s)
-
-        assert_equal(Glyph::STAR,     Glyph.lookup('*'))
-        assert_equal(Glyph::INFO,     Glyph.lookup('i'))
-        assert_equal(Glyph::QUESTION, Glyph.lookup('?'))
-        assert_equal(Glyph::CHECK,    Glyph.lookup('v'))
-        assert_equal(Glyph::X,        Glyph.lookup('x'))
-        assert_equal(Glyph::BUG,      Glyph.lookup('b'))
-        assert_equal(Glyph::CHEVRON,  Glyph.lookup('>'))
-
-        assert_raises(Glyph::InvalidGlyphHandle) do
-          Glyph.lookup('$')
-        end
+        assert_equal("\x1b[38;5;214m⧖\x1b[0m", Glyph::HOURGLASS.to_s)
+        assert_equal("\x1b[33m⚠️\x1b[0m", Glyph::WARNING.to_s)
       end
 
       def test_plain_glyphs
@@ -40,18 +30,24 @@ module CLI
           assert_equal("\x1b[31mX\x1b[0m", Glyph::X.to_s)
           assert_equal("\x1b[97m!\x1b[0m", Glyph::BUG.to_s)
           assert_equal("\x1b[33m»\x1b[0m", Glyph::CHEVRON.to_s)
+          assert_equal("\x1b[38;5;214mH\x1b[0m", Glyph::HOURGLASS.to_s)
+          assert_equal("\x1b[33m!\x1b[0m", Glyph::WARNING.to_s)
+        end
+      end
 
-          assert_equal(Glyph::STAR,     Glyph.lookup('*'))
-          assert_equal(Glyph::INFO,     Glyph.lookup('i'))
-          assert_equal(Glyph::QUESTION, Glyph.lookup('?'))
-          assert_equal(Glyph::CHECK,    Glyph.lookup('v'))
-          assert_equal(Glyph::X,        Glyph.lookup('x'))
-          assert_equal(Glyph::BUG,      Glyph.lookup('b'))
-          assert_equal(Glyph::CHEVRON,  Glyph.lookup('>'))
+      def test_glyph_lookup
+        assert_equal(Glyph::STAR,      Glyph.lookup('*'))
+        assert_equal(Glyph::INFO,      Glyph.lookup('i'))
+        assert_equal(Glyph::QUESTION,  Glyph.lookup('?'))
+        assert_equal(Glyph::CHECK,     Glyph.lookup('v'))
+        assert_equal(Glyph::X,         Glyph.lookup('x'))
+        assert_equal(Glyph::BUG,       Glyph.lookup('b'))
+        assert_equal(Glyph::CHEVRON,   Glyph.lookup('>'))
+        assert_equal(Glyph::HOURGLASS, Glyph.lookup('H'))
+        assert_equal(Glyph::WARNING,   Glyph.lookup('!'))
 
-          assert_raises(Glyph::InvalidGlyphHandle) do
-            Glyph.lookup('$')
-          end
+        assert_raises(Glyph::InvalidGlyphHandle) do
+          Glyph.lookup('$')
         end
       end
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/deploys/issues/1478

- c476c9bf93cc12a706973c64a5570b1bc2a7ef04: Fix the bug, with hard-coded tests
- 25d1ee48718a86353cb3ff18f4bdadf7ab91d4d6: Improve tests to be more dynamic and mitigate a bug like this in the future

This was [discovered in conveyor](https://github.com/shop/world/blob/64f6378f32173019826fb1ee85dab32024a6471c/areas/tools/dev/lib/conveyor/commands/deploy_release.rb#L23) when attempting to print the hourglass glyph with `{{H}}` and the `orange` color was not available to the formatter.

```
/opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:136:in `rescue in block in apply_format': invalid format specifier: orange (CLI::ui::Formatter::FormatError)
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:133:in `block in apply_format'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:130:in `each'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:130:in `each_with_object'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:130:in `apply_format'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:109:in `block in format'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:107:in `each'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:107:in `each_with_object'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:107:in `format'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui.rb:176:in `fmt'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:166:in `stderr_puts'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:129:in `rescue in triage_all_exceptions'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:96:in `triage_all_exceptions'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:64:in `call'
	from /opt/dev-dist/revisions/6814a86/bin/conveyor:78:in `<main>'
/opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:134:in `fetch': key not found: "orange" (KeyError)
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:134:in `block in apply_format'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:130:in `each'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:130:in `each_with_object'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:130:in `apply_format'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:109:in `block in format'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:107:in `each'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:107:in `each_with_object'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/formatter.rb:107:in `format'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui.rb:176:in `fmt'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:166:in `stderr_puts'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:129:in `rescue in triage_all_exceptions'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:96:in `triage_all_exceptions'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:64:in `call'
	from /opt/dev-dist/revisions/6814a86/bin/conveyor:78:in `<main>'
/opt/dev-dist/revisions/6814a86/lib/conveyor/commands/deploy_release.rb:245:in `check_required_branch_statuses': Missing or failing required status checks: (CLI::kit::Abort)
- {{H}} buildkite/world-shopify-post-merge-testing (pending)
- {{H}} buildkite/world-shopify-checks (pending)
- {{H}} buildkite/world-shopify-production-builder (pending)
You can follow up on the status checks here:
https://github.com/shop/world/commit/ad95c4478396ae44b95afabf9308c7aaae63cac4
	from /opt/dev-dist/revisions/6814a86/lib/conveyor/commands/deploy_release.rb:45:in `call'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/base_command.rb:24:in `call'
	from /opt/dev-dist/revisions/6814a86/lib/dev/command.rb:22:in `call'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/executor.rb:21:in `block (2 levels) in call'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/executor.rb:46:in `block (2 levels) in with_logging'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui/stdout_router.rb:341:in `with_id'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/executor.rb:45:in `block in with_logging'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-ui/lib/cli/ui.rb:315:in `log_output_to'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/executor.rb:44:in `with_logging'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/executor.rb:20:in `block in call'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/executor.rb:75:in `twrap'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/executor.rb:54:in `block in with_traps'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/executor.rb:75:in `twrap'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/executor.rb:53:in `with_traps'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/executor.rb:19:in `call'
	from /opt/dev-dist/revisions/6814a86/lib/dev/core_entry_point.rb:27:in `block in exec'
	from /opt/dev-dist/revisions/6814a86/lib/dev/monorail/log.rb:201:in `event'
	from /opt/dev-dist/revisions/6814a86/lib/dev/monorail/log.rb:56:in `invocation'
	from /opt/dev-dist/revisions/6814a86/lib/dev/core_entry_point.rb:26:in `exec'
	from /opt/dev-dist/revisions/6814a86/lib/conveyor/entry_point.rb:18:in `call'
	from /opt/dev-dist/revisions/6814a86/bin/conveyor:78:in `block in <main>'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:98:in `triage_all_exceptions'
	from /opt/dev-dist/revisions/6814a86/vendor/deps/cli-kit/lib/cli/kit/error_handler.rb:64:in `call'
	from /opt/dev-dist/revisions/6814a86/bin/conveyor:78:in `<main>'
```