### PR TITLE
Allow CLI::UI.ask to work without a question parameter

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)"
+    ],
+    "deny": []
+  }
+}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cli-ui (2.3.1)
+    cli-ui (2.4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,6 +14,7 @@ GEM
     docile (1.4.0)
     erubi (1.13.0)
     json (2.9.1)
+    json (2.9.1-java)
     language_server-protocol (3.17.0.4)
     method_source (1.1.0)
     minitest (5.25.4)
@@ -31,6 +32,7 @@ GEM
       racc
     prism (1.2.0)
     racc (1.8.1)
+    racc (1.8.1-java)
     rainbow (3.1.1)
     rake (13.2.1)
     rbi (0.2.1)
@@ -66,6 +68,7 @@ GEM
     sorbet (0.5.11781)
       sorbet-static (= 0.5.11781)
     sorbet-runtime (0.5.11781)
+    sorbet-static (0.5.11781-java)
     sorbet-static (0.5.11781-universal-darwin)
     sorbet-static (0.5.11781-x86_64-linux)
     sorbet-static-and-runtime (0.5.11781)

--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -105,7 +105,7 @@ module CLI
       # Convenience Method for +CLI::UI::Prompt.ask+
       sig do
         params(
-          question: String,
+          question: T.nilable(String),
           options: T.nilable(T::Array[String]),
           default: T.nilable(T.any(String, T::Array[String])),
           is_file: T::Boolean,
@@ -117,7 +117,7 @@ module CLI
         ).returns(T.any(String, T::Array[String]))
       end
       def ask(
-        question,
+        question = nil,
         options: nil,
         default: nil,
         is_file: false,

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -48,7 +48,7 @@ module CLI
         #
         # ==== Attributes
         #
-        # * +question+ - (required) The question to ask the user
+        # * +question+ - (optional) The question to ask the user
         #
         # ==== Options
         #
@@ -104,7 +104,7 @@ module CLI
         #
         sig do
           params(
-            question: String,
+            question: T.nilable(String),
             options: T.nilable(T::Array[String]),
             default: T.nilable(T.any(String, T::Array[String])),
             is_file: T::Boolean,
@@ -116,7 +116,7 @@ module CLI
           ).returns(T.any(String, T::Array[String]))
         end
         def ask(
-          question,
+          question = nil,
           options: nil,
           default: nil,
           is_file: false,
@@ -234,7 +234,7 @@ module CLI
         private
 
         sig do
-          params(question: String, default: T.nilable(String), is_file: T::Boolean, allow_empty: T::Boolean)
+          params(question: T.nilable(String), default: T.nilable(String), is_file: T::Boolean, allow_empty: T::Boolean)
             .returns(String)
         end
         def ask_free_form(question, default, is_file, allow_empty)
@@ -245,7 +245,7 @@ module CLI
           CLI::UI::StdoutRouter::Capture.in_alternate_screen do
             if default
               puts_question("#{question} (empty = #{default})")
-            else
+            elsif question
               puts_question(question)
             end
 
@@ -267,7 +267,7 @@ module CLI
 
         sig do
           params(
-            question: String,
+            question: T.nilable(String),
             options: T.nilable(T::Array[String]),
             multiple: T::Boolean,
             default: T.nilable(T.any(String, T::Array[String])),
@@ -299,7 +299,9 @@ module CLI
           resp = T.let([], T.any(String, T::Array[String]))
 
           CLI::UI::StdoutRouter::Capture.in_alternate_screen do
-            puts_question("#{question} " + instructions_color.code + "(#{instructions})" + Color::RESET.code)
+            if question
+              puts_question("#{question} " + instructions_color.code + "(#{instructions})" + Color::RESET.code)
+            end
             resp = interactive_prompt(options, multiple: multiple, default: default)
 
             # Clear the line

--- a/lib/cli/ui/version.rb
+++ b/lib/cli/ui/version.rb
@@ -3,6 +3,6 @@
 
 module CLI
   module UI
-    VERSION = '2.3.1'
+    VERSION = '2.4.0'
   end
 end

--- a/test/cli/ui/prompt_test.rb
+++ b/test/cli/ui/prompt_test.rb
@@ -183,6 +183,12 @@ module CLI
         assert_output_includes('--zxcv--')
       end
 
+      def test_ask_without_question_or_default
+        run_in_process('puts "--#{CLI::UI::Prompt.ask}--"')
+        write("user input\n")
+        assert_output_includes('--user input--')
+      end
+
       def test_ask_invalid_kwargs
         error = assert_raises(ArgumentError) { Prompt.ask('q', options: ['a'], is_file: true) }
         assert_equal('conflicting arguments: is_file is only useful when options are not provided', error.message)


### PR DESCRIPTION
## Summary
- Make the `question` parameter optional in `CLI::UI.ask` and `CLI::UI::Prompt.ask` methods
- This enhances flexibility by allowing simpler prompts when a question isn't needed
- Add a test to validate the new functionality

I want to be able to use cli-ui to repeatedly query the user for input. Since there isn't really a question, I'm looking to avoid having the question and the `?` used on the preceding line each time.