### PR TITLE
Resolve circular require issue

### DIFF
--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
-
 module CLI
   module UI
     module ANSI

--- a/lib/cli/ui/color.rb
+++ b/lib/cli/ui/color.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
-
 module CLI
   module UI
     class Color

--- a/lib/cli/ui/frame.rb
+++ b/lib/cli/ui/frame.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
 require 'cli/ui/frame/frame_stack'
 require 'cli/ui/frame/frame_style'
 

--- a/lib/cli/ui/glyph.rb
+++ b/lib/cli/ui/glyph.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
-
 module CLI
   module UI
     class Glyph

--- a/lib/cli/ui/printer.rb
+++ b/lib/cli/ui/printer.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
-
 module CLI
   module UI
     class Printer

--- a/lib/cli/ui/progress.rb
+++ b/lib/cli/ui/progress.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
-
 module CLI
   module UI
     class Progress

--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -2,7 +2,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
 begin
   require 'reline' # For 2.7+
 rescue LoadError

--- a/lib/cli/ui/spinner.rb
+++ b/lib/cli/ui/spinner.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
-
 module CLI
   module UI
     module Spinner

--- a/lib/cli/ui/stdout_router.rb
+++ b/lib/cli/ui/stdout_router.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
 require 'stringio'
 require_relative '../../../vendor/reentrant_mutex'
 

--- a/lib/cli/ui/terminal.rb
+++ b/lib/cli/ui/terminal.rb
@@ -1,7 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
 require 'io/console'
 
 module CLI

--- a/lib/cli/ui/truncater.rb
+++ b/lib/cli/ui/truncater.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
-
 module CLI
   module UI
     # Truncater truncates a string to a provided printable width.

--- a/lib/cli/ui/wrap.rb
+++ b/lib/cli/ui/wrap.rb
@@ -2,7 +2,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui'
 require 'cli/ui/frame/frame_stack'
 require 'cli/ui/frame/frame_style'
 


### PR DESCRIPTION
Closes #607 

A number of files are explicitly requiring `cli/ui` again, despite auto-loading making this unnecessary. This interacts poorly with loading in projects that use this gem, resulting in circular dependency warnings (especially when running rake tasks).

This PR removes these unneeded require statements.