### PR TITLE
Add explicit block parameter to SpinGroup#initialize

### DIFF
--- a/lib/cli/ui/prompt.rb
+++ b/lib/cli/ui/prompt.rb
@@ -252,8 +252,8 @@ module CLI
           end
         end
 
-        #: (String question, ?Array[String]? options, ?multiple: bool, ?default: (String | Array[String])?, ?filter_ui: bool, ?select_ui: bool) -> (String | Array[String])
-        def ask_interactive(question, options = nil, multiple: false, default: nil, filter_ui: true, select_ui: true)
+        #: (String question, ?Array[String]? options, ?multiple: bool, ?default: (String | Array[String])?, ?filter_ui: bool, ?select_ui: bool) ?{ (OptionsHandler) -> void } -> (String | Array[String])
+        def ask_interactive(question, options = nil, multiple: false, default: nil, filter_ui: true, select_ui: true, &block)
           raise(ArgumentError, 'conflicting arguments: options and block given') if options && block_given?
 
           options ||= if block_given?

--- a/lib/cli/ui/spinner/spin_group.rb
+++ b/lib/cli/ui/spinner/spin_group.rb
@@ -59,8 +59,8 @@ module CLI
         #
         # https://user-images.githubusercontent.com/3074765/33798558-c452fa26-dce8-11e7-9e90-b4b34df21a46.gif
         #
-        #: (?auto_debrief: bool, ?interrupt_debrief: bool, ?max_concurrent: Integer, ?work_queue: WorkQueue?, ?to: io_like) -> void
-        def initialize(auto_debrief: true, interrupt_debrief: false, max_concurrent: 0, work_queue: nil, to: $stdout)
+        #: (?auto_debrief: bool, ?interrupt_debrief: bool, ?max_concurrent: Integer, ?work_queue: WorkQueue?, ?to: io_like) ?{ (SpinGroup) -> void } -> void
+        def initialize(auto_debrief: true, interrupt_debrief: false, max_concurrent: 0, work_queue: nil, to: $stdout, &block)
           @m = Mutex.new
           @tasks = []
           @puts_above = []


### PR DESCRIPTION
Updates `SpinGroup#initialize` and `Prompt#ask_interactive` params to include `&block`

In newer Sorbet versions [we are required to explicitly define `&block`](https://github.com/sorbet/sorbet/pull/9791) in method signatures and params when using `yield` in `# typed: true` files

This change will prevent [7035](https://sorbet.org/docs/error-reference#7035) errors in repos using both `cli-ui` and Sorbet versions 0.6.12889 and above