### PR TITLE
Fix circular requires to resolve bug and warnings

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        ruby-version: ['3.2', '3.3', '3.4']
+        ruby-version: ['3.3', '3.4', '4.0']
 
     runs-on: ${{ matrix.os }}
     env:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
       logger
       prism (>= 1.6.0)
       tsort
+    readline (0.0.4)
+      reline
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -137,6 +139,7 @@ DEPENDENCIES
   mocha
   parallel (< 2)
   rake (~> 13.0)
+  readline
   rubocop
   rubocop-rake
   rubocop-shopify

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ Rake::TestTask.new do |t|
   t.libs += ['test']
   t.test_files = FileList[File.join(TEST_ROOT, '**', '*_test.rb')]
   t.verbose = false
-  t.warning = false
+  t.warning = true
 end
 
 RuboCop::RakeTask.new(:style) do |t|

--- a/cli-ui.gemspec
+++ b/cli-ui.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency('minitest', '>= 5.0', '< 7')
   spec.add_development_dependency('rake', '~> 13.0')
+  spec.add_development_dependency('readline')
 end

--- a/lib/cli/ui/frame.rb
+++ b/lib/cli/ui/frame.rb
@@ -1,12 +1,12 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui/frame/frame_stack'
-require 'cli/ui/frame/frame_style'
-
 module CLI
   module UI
     module Frame
+      autoload :FrameStack, 'cli/ui/frame/frame_stack'
+      autoload :FrameStyle, 'cli/ui/frame/frame_style'
+
       class UnnestedFrameException < StandardError; end
       DEFAULT_FRAME_COLOR = CLI::UI.resolve_color(:cyan)
 

--- a/lib/cli/ui/frame/frame_style.rb
+++ b/lib/cli/ui/frame/frame_style.rb
@@ -1,8 +1,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui/frame'
-
 module CLI
   module UI
     module Frame

--- a/lib/cli/ui/wrap.rb
+++ b/lib/cli/ui/wrap.rb
@@ -2,9 +2,6 @@
 # typed: true
 # frozen_string_literal: true
 
-require 'cli/ui/frame/frame_stack'
-require 'cli/ui/frame/frame_style'
-
 module CLI
   module UI
     class Wrap

--- a/test/cli/ui/stdout_router_test.rb
+++ b/test/cli/ui/stdout_router_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'open3'
+require 'rbconfig'
 
 module CLI
   module UI
@@ -20,6 +22,37 @@ module CLI
         StdoutRouter.with_id(on_streams: [$stdout]) do |id|
           assert_equal({ id: id, streams: [$stdout] }, StdoutRouter.current_id)
         end
+      end
+
+      def test_frame_can_autoload_after_router_is_enabled
+        script = <<~RUBY
+          require 'stringio'
+          require 'cli/ui'
+
+          original_stdout = $stdout
+          original_stderr = $stderr
+
+          begin
+            $stdout = StringIO.new
+            $stderr = StringIO.new
+
+            CLI::UI::StdoutRouter.enable
+            $VERBOSE = true
+
+            CLI::UI::Frame.open('Repro') { puts 'body' }
+          ensure
+            if defined?(CLI::UI::StdoutRouter) && CLI::UI::StdoutRouter.enabled?($stdout)
+              CLI::UI::StdoutRouter.disable
+            end
+            $stdout = original_stdout
+            $stderr = original_stderr
+          end
+        RUBY
+
+        lib = File.expand_path('../../../lib', __dir__)
+        stdout, stderr, status = Open3.capture3(RbConfig.ruby, '-I', lib, '-e', script)
+
+        assert(status.success?, "stdout:\n#{stdout}\nstderr:\n#{stderr}")
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,14 +31,29 @@ def with_os_mock_and_reload(os, class_names = [], files = [])
   files = Array(files)
 
   CLI::UI::OS.stubs(:current).returns(os)
-  class_names.each { |classname| CLI::UI.send(:remove_const, classname) }
-  files.each { |file| load(file) }
+
+  # Delete the file and any files under a dir of the same name to cover autoloaded children.
+  delete_pattern = files.flat_map do |path|
+    file = File.realpath(path)
+    dir = file.delete_suffix('.rb')
+    [Regexp.escape(file), "#{Regexp.escape(dir)}/.+"]
+  end.join('|').then { |s| Regexp.new(s) }
+
+  reset = proc do
+    $LOADED_FEATURES.reject! do |feat|
+      feat.match?(delete_pattern)
+    end
+
+    class_names.each { |classname| CLI::UI.send(:remove_const, classname) }
+    files.each { |file| require(file) }
+  end
+
+  reset.call
 
   yield
 ensure
   CLI::UI::OS.unstub(:current)
-  class_names.each { |classname| CLI::UI.send(:remove_const, classname) }
-  files.each { |file| load(file) }
+  reset.call
 end
 
 require 'fileutils'


### PR DESCRIPTION
- Re-enable warnings in test suite

- Clean LOADED_FEATURES and use require to fix remaining test suite warnings

    such as

    > warning: method redefined; discarding old start

    and

    > warning: Expected cli/ui/spinner/async to define CLI::UI::Spinner::Async but it didn't

    closes #321

- Use autoload consistently instead of circular requires

   This fixes a load order problem on ruby head demonstrated by the new test.

- Ensure readline is in the gemspec as it is no longer default in ruby 4