### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cli-ui (2.7.0)
+    cli-ui (3.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/cli/ui/version.rb
+++ b/lib/cli/ui/version.rb
@@ -3,6 +3,6 @@
 
 module CLI
   module UI
-    VERSION = '2.7.0'
+    VERSION = '3.0.0'
   end
 end


### PR DESCRIPTION
BREAKING CHANGES:

- Ruby 3.1 support has been dropped; cli-ui now requires Ruby >= 3.2.
- The documented entrypoint remains require 'cli/ui'. Consumers requiring internal files directly, such as require 'cli/ui/color', may need to require 'cli/ui' first now that internal files no longer bootstrap the top-level file themselves.
- Passing timing: nil to CLI::UI.frame or CLI::UI::Frame.open now uses the default timing behavior. Pass timing: false to suppress elapsed timing.