### PR TITLE
Fix ANSI measurement / truncation / wrapping edge cases

### DIFF
--- a/lib/cli/ui.rb
+++ b/lib/cli/ui.rb
@@ -346,7 +346,7 @@ module CLI
 
         text = "{{blue:{{underline:#{text}}}}}" if blue_underline
         text = CLI::UI.fmt(text) if format
-        "\x1b]8;;#{url}\x1b\\#{text}\x1b]8;;\x1b\\"
+        ANSI.hyperlink(url, text)
       end
     end
 

--- a/lib/cli/ui/ansi.rb
+++ b/lib/cli/ui/ansi.rb
@@ -1,6 +1,9 @@
 # typed: true
 # frozen_string_literal: true
 
+require 'strscan'
+require_relative 'ansi/terminal_width'
+
 module CLI
   module UI
     module ANSI
@@ -9,35 +12,82 @@ module CLI
 
       ESC = "\x1b"
       # https://ghostty.org/docs/vt/concepts/sequences#csi-sequences
-      CSI_SEQUENCE = /\x1b\[[\d;:]+[\x20-\x2f]*?[\x40-\x7e]/
+      CSI_SEQUENCE = /\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/
       # https://ghostty.org/docs/vt/concepts/sequences#osc-sequences
       # OSC sequences can be terminated with either ST (\x1b\x5c) or BEL (\x07)
       OSC_SEQUENCE = /\x1b\][^\x07\x1b]*?(?:\x07|\x1b\x5c)/
-
+      # An OSC 8 hyperlink: \x1b]8;params;URI, terminated like any OSC
+      # sequence. One with a URI opens a link, one without closes it.
+      # Anchored, to classify a whole sequence as yielded by each_token.
+      HYPERLINK = /\A\x1b\]8;[^;]*;(?<uri>.*)(?:\x07|\x1b\x5c)\z/m
+      HYPERLINK_END = "\x1b]8;;\x1b\x5c"
+      # Any whole control sequence, for walking a string as alternating
+      # sequence and text runs.
+      SEQUENCE = Regexp.union(CSI_SEQUENCE, OSC_SEQUENCE)
+      # A CSI or OSC introducer whose sequence runs to the end of the
+      # string without a terminator — usually one sliced open by an
+      # upstream cut. Treating it as a sequence keeps its bytes out of
+      # width measurements and truncation windows.
+      UNTERMINATED_SEQUENCE = /\x1b[\[\]][^\x1b]*\z/
+      TEXT_RUN = /[^\x1b]+/
       class << self
-        # ANSI escape sequences (like \x1b[31m) have zero width.
-        # when calculating the padding width, we must exclude them.
-        # This also implements a basic version of utf8 character width calculation like
-        # we could get for real from something like utf8proc.
+        # Yields str as alternating runs of :sequence (one whole CSI or OSC
+        # sequence) and :text (everything between them). Sequences never
+        # straddle tokens, so a consumer that measures or cuts only at
+        # token boundaries cannot slice one open. A CSI or OSC sequence
+        # left unterminated at the end of the string is yielded as one
+        # :sequence token; any other stray ESC is yielded as text.
+        #
+        #: (String str) ?{ (Symbol kind, String token) -> void } -> Enumerator[[Symbol, String]]?
+        def each_token(str, &block)
+          return to_enum(:each_token, str) unless block_given?
+
+          scanner = StringScanner.new(str)
+          until scanner.eos?
+            if (sequence = scanner.scan(SEQUENCE) || scanner.scan(UNTERMINATED_SEQUENCE))
+              yield(:sequence, sequence)
+            elsif (text = scanner.scan(TEXT_RUN))
+              yield(:text, text)
+            else
+              yield(:text, scanner.getch.to_s)
+            end
+          end
+        end
+
+        # The number of terminal columns str occupies when printed: control
+        # sequences take none, and each grapheme cluster (not codepoint:
+        # 👩‍💻 is one cluster) is measured by grapheme_width.
         #
         #: (String str) -> Integer
         def printing_width(str)
-          zwj = false #: bool
-          strip_codes(str).codepoints.reduce(0) do |acc, cp|
-            if zwj
-              zwj = false
-              next acc
-            end
-            case cp
-            when 0x200d # zero-width joiner
-              zwj = true
-              acc
-            when "\n"
-              acc
+          # ASCII fast paths. Every ASCII grapheme cluster is one character
+          # wide except \n and \r, which are zero, so counting stands in for
+          # the cluster walk; with no ESC there are no sequences to skip and
+          # the whole string can be counted without tokenizing.
+          if str.ascii_only? && !str.include?(ESC)
+            return str.length - str.count("\n\r")
+          end
+
+          width = 0 #: Integer
+          each_token(str) do |kind, token|
+            next unless kind == :text
+
+            if token.ascii_only?
+              width += token.length - token.count("\n\r")
             else
-              acc + 1
+              token.grapheme_clusters.each do |cluster|
+                width += grapheme_width(cluster)
+              end
             end
           end
+          width
+        end
+
+        # The number of terminal columns one grapheme cluster occupies.
+        #
+        #: (String cluster) -> Integer
+        def grapheme_width(cluster)
+          TerminalWidth.grapheme_width(cluster)
         end
 
         # Strips ANSI codes from a str
@@ -94,6 +144,13 @@ module CLI
         #: (String params) -> String
         def sgr(params)
           control(params, 'm')
+        end
+
+        # Renders text as an OSC 8 hyperlink to url
+        #
+        #: (String url, String text) -> String
+        def hyperlink(url, text)
+          "\x1b]8;;#{url}\x1b\x5c#{text}#{HYPERLINK_END}"
         end
 
         # Cursor Movement

--- a/lib/cli/ui/ansi/replay.rb
+++ b/lib/cli/ui/ansi/replay.rb
@@ -474,9 +474,26 @@ module CLI
               when "\e" then next
               when "\x18", "\x1a" then return :ground
               when /[\x20-\x2f]/
-                # nF sequences: intermediate bytes, then one final byte.
-                scanner.skip(/[\x20-\x2f]*[\x30-\x7e]?/)
-                return :ground
+                return escape_intermediate(screen, scanner)
+              when SIMPLE_CONTROL then simple_control(screen, char)
+              else return :ground
+              end
+            end
+            :ground
+          end
+
+          # ESC intermediate state: collect through the final byte while
+          # executing embedded C0 controls and ignoring DEL. Bulk-skipping this
+          # tail would end the sequence at an embedded control, exposing its
+          # final byte as printable text.
+          #: (Screen screen, StringScanner scanner) -> Symbol
+          def escape_intermediate(screen, scanner)
+            until scanner.eos?
+              case (char = scanner.getch.to_s)
+              when /[\x30-\x7e]/ then return :ground
+              when /[\x20-\x2f]/ then next
+              when "\e" then return :escape
+              when "\x18", "\x1a" then return :ground
               when SIMPLE_CONTROL then simple_control(screen, char)
               else return :ground
               end
@@ -548,7 +565,10 @@ module CLI
             # tracks, except the alternate screen: a full-screen UI draws
             # there and a terminal discards it on exit, so it must not reach
             # the replayed scrollback either.
-            if params == '?1049'
+            if params.match?(/\A\?[\d;]*\z/)
+              modes = params.delete_prefix('?').split(';')
+              return unless modes.include?('1049')
+
               case final
               when 'h' then screen.enter_alternate
               when 'l' then screen.exit_alternate

--- a/lib/cli/ui/truncater.rb
+++ b/lib/cli/ui/truncater.rb
@@ -5,74 +5,57 @@ module CLI
   module UI
     # Truncater truncates a string to a provided printable width.
     module Truncater
-      PARSE_ROOT = :root
-      PARSE_ANSI = :ansi
-      PARSE_ESC  = :esc
-      PARSE_ZWJ  = :zwj
-
-      ESC                 = 0x1b
-      LEFT_SQUARE_BRACKET = 0x5b
-      ZWJ                 = 0x200d # emojipedia.org/emoji-zwj-sequences
-      SEMICOLON           = 0x3b
-
-      # EMOJI_RANGE in particular is super inaccurate. This is best-effort.
-      # If you need this to be more accurate, we'll almost certainly accept a
-      # PR improving it.
-      EMOJI_RANGE    = 0x1f300..0x1f5ff
-      NUMERIC_RANGE  = 0x30..0x39
-      LC_ALPHA_RANGE = 0x40..0x5a
-      UC_ALPHA_RANGE = 0x60..0x71
-
       TRUNCATED = "\x1b[0m…"
 
       class << self
         #: (String text, Integer printing_width) -> String
         def call(text, printing_width)
-          return text if text.size <= printing_width
+          # Fast path. Only sound for ASCII, where no character is wider
+          # than a column: an emoji string can occupy up to twice as many
+          # columns as it has characters.
+          return text if text.ascii_only? && text.size <= printing_width
 
-          width            = 0
-          mode             = PARSE_ROOT
-          truncation_index = nil #: Integer?
+          width = 0 #: Integer
+          truncated = false #: bool
+          open_hyperlink = false #: bool
+          # Preserve the caller's encoding. Printer can deliberately pass
+          # ASCII-compatible strings in encodings other than UTF-8, and an
+          # empty UTF-8 buffer becomes incompatible after binary text has
+          # been appended to it.
+          prefix = String.new(encoding: text.encoding)
 
-          codepoints = text.codepoints
-          codepoints.each.with_index do |cp, index|
-            case mode
-            when PARSE_ROOT
-              case cp
-              when ESC # non-printable, followed by some more non-printables.
-                mode = PARSE_ESC
-              when ZWJ # non-printable, followed by another non-printable.
-                mode = PARSE_ZWJ
-              else
-                width += width(cp)
-                if width >= printing_width
-                  truncation_index ||= index
-                  # it looks like we could break here but we still want the
-                  # width calculation for the rest of the characters.
+          ANSI.each_token(text) do |kind, token|
+            case kind
+            when :sequence
+              # Sequences occupy no columns. Any that fall past the cut are
+              # dropped: TRUNCATED resets SGR state itself, and an open
+              # hyperlink gets closed below.
+              next if truncated
+
+              prefix << token
+              if (match = ANSI::HYPERLINK.match(token))
+                open_hyperlink = !match[:uri].to_s.empty?
+              end
+            when :text
+              token.grapheme_clusters.each do |cluster|
+                # A line break is zero columns to printing_width, but a
+                # truncated string must stay one line: count it as a column
+                # so the cut lands before it, never absorbing it silently.
+                # Other zero-width clusters remain zero-width.
+                cluster_width = case cluster
+                when "\n", "\r", "\r\n"
+                  1
+                else
+                  ANSI.grapheme_width(cluster)
                 end
+                width += cluster_width
+                # We cut before the cluster that reaches printing_width,
+                # leaving one column for TRUNCATED's ellipsis, but keep
+                # measuring: if the rest of the string turns out not to
+                # exceed printing_width after all, no cut is needed.
+                truncated ||= width >= printing_width
+                prefix << cluster unless truncated
               end
-            when PARSE_ESC
-              mode = case cp
-              when LEFT_SQUARE_BRACKET
-                PARSE_ANSI
-              else
-                PARSE_ROOT
-              end
-            when PARSE_ANSI
-              # ANSI escape codes preeeetty much have the format of:
-              # \x1b[0-9;]+[A-Za-z]
-              case cp
-              when NUMERIC_RANGE, SEMICOLON
-              when LC_ALPHA_RANGE, UC_ALPHA_RANGE
-                mode = PARSE_ROOT
-              else
-                # unexpected. let's just go back to the root state I guess?
-                mode = PARSE_ROOT
-              end
-            when PARSE_ZWJ
-              # consume any character and consider it as having no width
-              # width(x+ZWJ+y) = width(x).
-              mode = PARSE_ROOT
             end
           end
 
@@ -81,22 +64,21 @@ module CLI
           # It's specifically for the case where we decided "Yes, this is the
           # point at which we'd have to add a truncation!" but it's actually
           # the end of the string.
-          return text if !truncation_index || width <= printing_width
+          return text if !truncated || width <= printing_width
 
-          slice = codepoints[0...truncation_index] #: as !nil
-          slice.pack('U*') + TRUNCATED
+          prefix << ANSI::HYPERLINK_END.encode(text.encoding) if open_hyperlink
+          prefix << truncation_marker(text.encoding)
         end
 
         private
 
-        #: (Integer printable_codepoint) -> Integer
-        def width(printable_codepoint)
-          case printable_codepoint
-          when EMOJI_RANGE
-            2
-          else
-            1
-          end
+        # Keep the reset and marker in the input encoding. Some
+        # ASCII-compatible encodings cannot represent U+2026; a one-column
+        # question mark preserves the width contract in that case.
+        #
+        #: (Encoding encoding) -> String
+        def truncation_marker(encoding)
+          TRUNCATED.encode(encoding, invalid: :replace, undef: :replace, replace: '?')
         end
       end
     end

--- a/lib/cli/ui/wrap.rb
+++ b/lib/cli/ui/wrap.rb
@@ -5,6 +5,10 @@
 module CLI
   module UI
     class Wrap
+      # SGR parameters are separated by ; or, in the underspecified-but-real
+      # colon form of extended colors (\x1b[38:2::255:0:0m), by :.
+      SGR = /\A\x1b\[[\d;:]*m\z/
+
       #: (String input) -> void
       def initialize(input)
         @input = input
@@ -14,43 +18,143 @@ module CLI
       def wrap(total_width = Terminal.width)
         max_width = total_width - Frame.prefix_width
         width = 0 #: Integer
-        final = []
-        # Create an alternation of format codes of parameter lengths 1-20, since + and {1,n} not allowed in lookbehind
-        format_codes = (1..20).map { |n| /\x1b\[[\d;]{#{n}}m/ }.join('|')
-        codes = ''
-        @input.split(/(?=\s|\x1b\[[\d;]+m|\r)|(?<=\s|#{format_codes})/).each do |token|
-          case token
-          when '\x1B[0?m'
-            codes = ''
-            final << token
-          when /\x1b\[[\d;]+m/
-            codes += token # Track in use format codes so that they are resent after frame coloring
-            final << token
-          when "\n"
-            final << "\n#{codes}"
-            width = 0
-          when /\s/
-            token_width = ANSI.printing_width(token)
-            if width + token_width <= max_width
-              final << token
-              width += token_width
-            else
-              final << "\n#{codes}"
-              width = 0
+        final = +''
+        # SGR codes in effect, resent after each line break so that frame
+        # coloring doesn't clobber them mid-paragraph. An open hyperlink
+        # likewise gets closed at the break and reopened after it, keeping
+        # the frame gutter outside the link.
+        sgr_state = {} #: Hash[String, String]
+        open_hyperlink = nil #: String?
+        break_line = -> do
+          final << ANSI::HYPERLINK_END if open_hyperlink
+          final << "\n" << active_sgr(sgr_state) << open_hyperlink.to_s
+          width = 0
+        end
+
+        ANSI.each_token(@input) do |kind, token|
+          if kind == :sequence
+            case token
+            when SGR
+              track_sgr(token, sgr_state)
+            when ANSI::HYPERLINK
+              match = ANSI::HYPERLINK.match(token) #: as !nil
+              open_hyperlink = match[:uri].to_s.empty? ? nil : token
             end
-          else
-            token_width = ANSI.printing_width(token)
-            if width + token_width <= max_width
-              final << token
-              width += token_width
+            final << token
+            next
+          end
+
+          # Split the text run so each whitespace character is its own
+          # token: lines break at whitespace, and a space that would sit in
+          # the last column becomes the break itself.
+          token.split(/(?=\s)|(?<=\s)/).each do |chunk|
+            if chunk == "\n"
+              break_line.call
+              next
+            end
+
+            chunk_width = ANSI.printing_width(chunk)
+            if width + chunk_width <= max_width
+              final << chunk
+              width += chunk_width
+            elsif chunk.match?(/\A\s\z/)
+              break_line.call
             else
-              final << "\n#{codes}"
-              final << token
-              width = token_width
+              break_line.call
+              final << chunk
+              width = chunk_width
             end
           end
         end
-        final.join
+        final
+      end
+
+      private
+
+      # Reconstructs the active SGR commands as one deduplicated sequence.
+      #
+      #: (Hash[String, String] state) -> String
+      def active_sgr(state)
+        state.empty? ? '' : "\e[#{state.values.join(";")}m"
+      end
+
+      # Keeps only the most recent command for each SGR parameter, with shared
+      # slots for the color commands whose payloads can vary. Deleting before
+      # reinserting preserves the order of each command's last occurrence, so
+      # an on/off/on sequence replays in the same effective order without
+      # retaining the full formatting history.
+      #
+      # A reset can hide mid-list: parameters reset at a 0 or an empty entry
+      # (\e[0;33m, \e[;1m), while zeros inside a colon-form parameter are
+      # subparameters rather than commands.
+      #
+      #: (String token, Hash[String, String] state) -> void
+      def track_sgr(token, state)
+        params = token[2...-1].to_s.split(';', -1)
+        params = ['0'] if params.empty?
+        index = 0
+        while index < params.length
+          param = params.fetch(index)
+          param = '0' if param.empty?
+          code = param.split(':', 2).first.to_i
+          command = param
+          consumed = 0
+
+          if code == 38 || code == 48 || code == 58
+            command, consumed = color_command(params, index)
+          end
+          remember_sgr(state, code, command) if command
+          index += consumed + 1
+        end
+      end
+
+      # Semicolon-form extended colors consume their following parameters;
+      # colon-form colors are already one parameter and need no grouping.
+      #
+      #: (Array[String] params, Integer index) -> [String?, Integer]
+      def color_command(params, index)
+        param = params.fetch(index)
+        return [param, 0] if param.include?(':')
+
+        case params[index + 1]
+        when '5'
+          return [nil, params.length - index - 1] if params[index + 2].nil?
+
+          [params[index, 3].to_a.join(';'), 2]
+        when '2'
+          length = params[index + 2].to_s.empty? ? 6 : 5
+          return [nil, params.length - index - 1] if params.length < index + length
+
+          [params[index, length].to_a.join(';'), length - 1]
+        else
+          [nil, 0]
+        end
+      end
+
+      #: (Hash[String, String] state, Integer code, String command) -> void
+      def remember_sgr(state, code, command)
+        if code.zero?
+          state.clear
+          return
+        end
+
+        key = sgr_key(code)
+        state.delete(key)
+        state[key] = command
+      end
+
+      #: (Integer code) -> String
+      def sgr_key(code)
+        case code
+        when 30..39, 90..97
+          'foreground'
+        when 40..49, 100..107
+          'background'
+        when 58, 59
+          'underline_color'
+        else
+          code.to_s
+        end
       end
     end
   end

--- a/test/cli/ui/ansi/replay_test.rb
+++ b/test/cli/ui/ansi/replay_test.rb
@@ -134,6 +134,14 @@ module CLI
           assert_equal("x\nred", Replay.render("x\e[3\n1mred"))
         end
 
+        # Controls embedded after an ESC intermediate do not end its sequence:
+        # C0 controls execute, DEL is ignored, and the eventual final is still
+        # consumed.
+        def test_embedded_controls_do_not_end_escape_intermediate_sequences
+          assert_equal('az', Replay.render("ab\e(\bBz"))
+          assert_equal('Az', Replay.render("A\e(\x7fBz"))
+        end
+
         # A parameter byte arriving after an intermediate puts a terminal in
         # its ignore state: the sequence is consumed but not executed.
         def test_out_of_order_csi_bytes_ignore_the_sequence
@@ -157,6 +165,8 @@ module CLI
           # An unmatched exit and a doubled enter change nothing.
           assert_equal('ab', Replay.render("a\e[?1049lb"))
           assert_equal('ab', Replay.render("a\e[?1049h\e[?1049hx\e[?1049lb"))
+          # DECSET and DECRST apply every mode in a semicolon-separated list.
+          assert_equal('ab', Replay.render("a\e[?25;1049hLOST\e[?25;1049lb"))
         end
 
         # StdoutRouter's in_alternate_screen re-prints everything captured

--- a/test/cli/ui/ansi_test.rb
+++ b/test/cli/ui/ansi_test.rb
@@ -9,14 +9,140 @@ module CLI
         assert_equal("\x1b[1;34m", ANSI.sgr('1;34'))
       end
 
+      def test_hyperlink
+        assert_equal("\e]8;;https://example.com\e\\text\e]8;;\e\\", ANSI.hyperlink('https://example.com', 'text'))
+      end
+
       def test_printing_width
         assert_equal(4, ANSI.printing_width("\x1b[38;2;100;100;100mtest\x1b[0m"))
         assert_equal(0, ANSI.printing_width(''))
 
-        assert_equal(3, ANSI.printing_width('>🔧<'))
-        assert_equal(1, ANSI.printing_width('👩‍💻'))
+        # Emoji occupy two columns, matching what Truncater has always
+        # assumed. A ZWJ sequence is one grapheme cluster, so one emoji.
+        assert_equal(4, ANSI.printing_width('>🔧<'))
+        assert_equal(2, ANSI.printing_width('👩‍💻'))
+
+        # Newlines and combining marks occupy no columns.
+        assert_equal(2, ANSI.printing_width("a\nb"))
+        assert_equal(1, ANSI.printing_width("e\u0301"))
+
+        # Mixed sequences, emoji, and ASCII in one string.
+        assert_equal(5, ANSI.printing_width("\e[31m\u{1f527} ok\e[0m"))
 
         assert_equal(4, ANSI.printing_width(UI.link('url', 'text')))
+      end
+
+      def test_printing_width_covers_wide_glyphs_beyond_the_core_emoji_block
+        # BMP emoji outside the U+1F300 block, SMP emoji beyond U+1F5FF,
+        # and CJK are all two columns wide.
+        assert_equal(2, ANSI.printing_width('✅'))
+        assert_equal(2, ANSI.printing_width('⭐'))
+        assert_equal(2, ANSI.printing_width('🚀'))
+        assert_equal(2, ANSI.printing_width('🛒'))
+        assert_equal(2, ANSI.printing_width('😀'))
+        assert_equal(4, ANSI.printing_width('漢字'))
+
+        # VS16 asks for emoji presentation: U+26A0 alone is a narrow text
+        # glyph, but ⚠️ (U+26A0 + VS16) renders two columns wide. This is
+        # Glyph::WARNING's form.
+        assert_equal(1, ANSI.printing_width("\u{26a0}"))
+        assert_equal(2, ANSI.printing_width("\u{26a0}\u{fe0f}"))
+
+        # A flag is two regional indicators forming one wide cluster.
+        assert_equal(2, ANSI.printing_width('🇨🇦'))
+
+        # Narrow neighbours of wide ranges stay narrow.
+        assert_equal(1, ANSI.printing_width('✓'))
+        assert_equal(1, ANSI.printing_width('⭑'))
+      end
+
+      def test_ascii_measurement_does_not_tokenize
+        ANSI.expects(:each_token).never
+
+        assert_equal(5, ANSI.printing_width('plain'))
+      end
+
+      def test_each_token_rejoins_every_input
+        rng = Random.new(20260812)
+        fragments = [
+          'plain',
+          ' ',
+          "\n",
+          '漢字',
+          '👩‍💻',
+          "e\u0301",
+          "\e[31m",
+          "\e[0m",
+          "\e[?25l",
+          "\e[K",
+          "\e]8;;https://example.com\e\\",
+          ANSI::HYPERLINK_END,
+          "\e",
+        ]
+
+        500.times do
+          input = Array.new(rng.rand(0..30)) { fragments.sample(random: rng) }.join
+          rejoined = ANSI.each_token(input).map { |_kind, token| token }.join
+
+          assert_equal(input, rejoined)
+        end
+      end
+
+      def test_each_token_yields_whole_sequences_and_text
+        tokens = []
+        ANSI.each_token("a\e[?25l\e]8;;https://x\e\\b") { |kind, token| tokens << [kind, token] }
+        assert_equal(
+          [
+            [:text, 'a'],
+            [:sequence, "\e[?25l"],
+            [:sequence, "\e]8;;https://x\e\\"],
+            [:text, 'b'],
+          ],
+          tokens,
+        )
+      end
+
+      def test_each_token_without_a_block_returns_an_enumerator
+        enum = ANSI.each_token("a\e[31mb")
+
+        assert_kind_of(Enumerator, enum)
+        assert_equal([[:text, 'a'], [:sequence, "\e[31m"], [:text, 'b']], enum.to_a)
+        assert_equal([], ANSI.each_token('').to_a)
+      end
+
+      def test_each_token_yields_stray_escape_as_text
+        tokens = []
+        ANSI.each_token("a\eb") { |kind, token| tokens << [kind, token] }
+        assert_equal([[:text, 'a'], [:text, "\e"], [:text, 'b']], tokens)
+      end
+
+      def test_each_token_yields_a_trailing_unterminated_sequence_whole
+        # A sequence sliced open by an upstream cut runs to the end of the
+        # string with no terminator. It stays one zero-width token instead
+        # of being counted (and sliced again) as text.
+        assert_equal([[:text, 'a'], [:sequence, "\e[31"]], ANSI.each_token("a\e[31").to_a)
+        assert_equal([[:sequence, "\e]8;;http://x"]], ANSI.each_token("\e]8;;http://x").to_a)
+
+        # Mid-string, an unterminated sequence is still text: only at the
+        # end of the string is a missing terminator unambiguous.
+        assert_equal(
+          [[:text, "\e"], [:text, '[31'], [:sequence, "\e[0m"]],
+          ANSI.each_token("\e[31\e[0m").to_a,
+        )
+      end
+
+      # CSI sequences aren't required to carry parameters (\e[K, \e[m), and
+      # private-mode sequences mark theirs with ? (\e[?25l). None of them
+      # print anything.
+      def test_printing_width_of_parameterless_and_private_sequences_is_zero
+        assert_equal(1, ANSI.printing_width("\e[?25lx\e[K"))
+        assert_equal(4, ANSI.printing_width("\e[mtest\e[0m"))
+      end
+
+      def test_strip_codes_removes_parameterless_and_private_sequences
+        assert_equal('x', ANSI.strip_codes("\e[?25lx\e[K"))
+        assert_equal('shown', ANSI.strip_codes("#{ANSI.hide_cursor}shown#{ANSI.show_cursor}"))
+        assert_equal('saved', ANSI.strip_codes("#{ANSI.cursor_save}saved#{ANSI.cursor_restore}"))
       end
 
       def test_strip_codes_preserves_text_between_osc8_hyperlinks

--- a/test/cli/ui/truncater_test.rb
+++ b/test/cli/ui/truncater_test.rb
@@ -22,6 +22,108 @@ module CLI
         assert_example(3, 'AB' + MAN_COOKING, 'AB' + Truncater::TRUNCATED)
       end
 
+      def test_truncate_never_slices_a_sequence
+        # Private-mode (\x1b[?25l) and parameterless (\x1b[K) sequences pass
+        # through whole and spend no width; those past the cut are dropped.
+        assert_example(3, "\x1b[?25lfoobar\x1b[K", "\x1b[?25lfo" + Truncater::TRUNCATED)
+      end
+
+      def test_truncate_treats_a_trailing_unterminated_sequence_as_a_sequence
+        # A sequence already sliced open (by an upstream cut, say) spends
+        # no width: past the cut it drops, and alone it passes unchanged.
+        assert_example(3, "foobar\x1b]8;;http://x", 'fo' + Truncater::TRUNCATED)
+        input = "\x1b]8;;http://x  no-terminator"
+        assert_example(5, input, input)
+      end
+
+      def test_truncate_measures_by_column_not_character
+        # Each 🌈 is one character but two columns; a character-count
+        # shortcut would pass these through six columns wide.
+        assert_example(1, '🔧', Truncater::TRUNCATED)
+        assert_example(3, '🌈🌈🌈', '🌈' + Truncater::TRUNCATED)
+      end
+
+      def test_truncate_cuts_before_a_line_break
+        # printing_width counts a newline as zero columns, but a truncated
+        # string must stay one line: the cut lands before the break.
+        assert_example(3, "ab\ncd", 'ab' + Truncater::TRUNCATED)
+        assert_example(3, "🌈\ncd", '🌈' + Truncater::TRUNCATED)
+      end
+
+      def test_truncate_does_not_count_other_zero_width_clusters
+        zero_width = "\u200b"
+        ANSI.stubs(:grapheme_width).returns(1)
+        ANSI.stubs(:grapheme_width).with(zero_width).returns(0)
+
+        assert_example(3, "a#{zero_width}bcde", "a#{zero_width}b" + Truncater::TRUNCATED)
+      end
+
+      def test_truncate_closes_an_open_hyperlink
+        link = "\x1b]8;;https://example.com\x1b\\foobar\x1b]8;;\x1b\\"
+        assert_example(
+          3,
+          link,
+          "\x1b]8;;https://example.com\x1b\\fo" + ANSI::HYPERLINK_END + Truncater::TRUNCATED,
+        )
+      end
+
+      def test_truncate_does_not_close_an_already_closed_hyperlink
+        input = "\x1b]8;;u\x1b\\a\x1b]8;;\x1b\\bcdef"
+        assert_example(3, input, "\x1b]8;;u\x1b\\a\x1b]8;;\x1b\\b" + Truncater::TRUNCATED)
+      end
+
+      def test_truncate_preserves_non_utf_8_encodings
+        binary = "\xc3\xa9abcdef".b
+        binary_result = Truncater.call(binary, 4)
+        assert_equal("\xc3\xa9a\e[0m?".b, binary_result)
+        assert_equal(Encoding::ASCII_8BIT, binary_result.encoding)
+
+        latin1 = 'éabcdef'.encode(Encoding::ISO_8859_1)
+        latin1_result = Truncater.call(latin1, 4)
+        assert_equal("éab\e[0m?".encode(Encoding::ISO_8859_1), latin1_result)
+        assert_equal(Encoding::ISO_8859_1, latin1_result.encoding)
+
+        windows_1252 = 'éabcdef'.encode(Encoding::Windows_1252)
+        windows_1252_result = Truncater.call(windows_1252, 4)
+        assert_equal("éab\e[0m…".encode(Encoding::Windows_1252), windows_1252_result)
+        assert_equal(Encoding::Windows_1252, windows_1252_result.encoding)
+      end
+
+      def test_truncate_invariants
+        rng = Random.new(20260812)
+        fragments = [
+          'plain',
+          ' ',
+          "\n",
+          '漢字',
+          '🔧',
+          "e\u0301",
+          "\e[31m",
+          "\e[0m",
+          "\e[?25l",
+          "\e[K",
+          "\e]8;;https://example.com\e\\",
+          ANSI::HYPERLINK_END,
+        ]
+
+        250.times do
+          input = Array.new(rng.rand(1..20)) { fragments.sample(random: rng) }.join
+          (1..12).each do |width|
+            result = Truncater.call(input, width)
+
+            assert_operator(ANSI.printing_width(result), :<=, width)
+            next if result == input
+
+            ANSI.each_token(result) do |kind, token|
+              next unless kind == :sequence
+
+              complete = ANSI::CSI_SEQUENCE.match?(token) || ANSI::OSC_SEQUENCE.match?(token)
+              assert(complete, "truncation left an incomplete sequence: #{token.inspect}")
+            end
+          end
+        end
+      end
+
       private
 
       def assert_example(width, from, to)

--- a/test/cli/ui/wide_glyph_layout_test.rb
+++ b/test/cli/ui/wide_glyph_layout_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module CLI
+  module UI
+    # Locks ANSI's width table into real layout: a wide glyph measured one
+    # column short would shift every character after it in these strings.
+    # Expectations are spelled out as exact output rather than measured
+    # with printing_width, which is the very thing under test. Color and
+    # cursor movement are disabled so layout arrives as plain text instead
+    # of repaints.
+    class WideGlyphLayoutTest < Minitest::Test
+      def setup
+        CLI::UI.enable_color = false
+        CLI::UI.enable_cursor = false
+        super
+      end
+
+      def teardown
+        CLI::UI.enable_color = true
+        CLI::UI.enable_cursor = true
+        super
+      end
+
+      def test_frame_pads_an_emoji_title_like_a_plain_one
+        Terminal.stubs(:width).returns(20)
+
+        with_emoji = capture_io { Frame.open('🚀 go', timing: false) {} }.first.lines.first.chomp
+        plain = capture_io { Frame.open('ab go', timing: false) {} }.first.lines.first.chomp
+
+        assert_equal('┏━━ 🚀 go ━━━━━━━━━', with_emoji)
+        # 🚀 spans two columns, like 'ab': the rules must line up.
+        assert_equal('┏━━ ab go ━━━━━━━━━', plain)
+      end
+
+      def test_table_pads_emoji_cells_by_column
+        rows = Table.capture_table([['✅ pass', 'ok'], ['status', 'ok']])
+
+        assert_equal(['✅ pass ok', 'status  ok'], rows)
+      end
+
+      def test_spin_group_truncates_a_vs16_glyph_title_by_column
+        Terminal.stubs(:width).returns(12)
+
+        out, _ = capture_io do
+          StdoutRouter.ensure_activated
+          sg = Spinner::SpinGroup.new
+          sg.add('⚠️ wide glyph title') { true }
+          sg.wait
+        end
+
+        # ⚠️ (U+26A0 + VS16) takes two columns, so twelve fill at the g.
+        assert_equal("✓ ⚠️ wide g\e[0m…", out.lines.last.chomp)
+      end
+    end
+  end
+end

--- a/test/cli/ui/wrap_test.rb
+++ b/test/cli/ui/wrap_test.rb
@@ -14,6 +14,85 @@ module CLI
         Terminal.stubs(:width).returns(20)
         assert_equal(ex, w.wrap)
       end
+
+      def test_wrap_resends_active_codes_after_a_break
+        wrapped = Wrap.new("\x1b[31maaaa bbbb cccc").wrap(9)
+
+        assert_equal("\x1b[31maaaa bbbb\n\x1b[31mcccc", wrapped)
+      end
+
+      def test_wrap_stops_resending_codes_after_a_reset
+        wrapped = Wrap.new("\x1b[31maaaa\x1b[0m bbbb cccc").wrap(9)
+
+        assert_equal("\x1b[31maaaa\x1b[0m bbbb\ncccc", wrapped)
+      end
+
+      def test_wrap_detects_a_reset_hidden_in_a_parameter_list
+        # \e[0;33m resets, then applies 33: earlier codes die at the reset
+        # and only the survivors are resent after a break.
+        wrapped = Wrap.new("\x1b[1m\x1b[0;33maaaa bbbb cccc").wrap(9)
+
+        assert_equal("\x1b[1m\x1b[0;33maaaa bbbb\n\x1b[33mcccc", wrapped)
+      end
+
+      def test_wrap_detects_an_empty_parameter_as_a_reset
+        # An empty SGR parameter (\e[;m) is a 0 to a terminal.
+        wrapped = Wrap.new("\x1b[31maaaa\x1b[;m bbbb cccc").wrap(9)
+
+        assert_equal("\x1b[31maaaa\x1b[;m bbbb\ncccc", wrapped)
+      end
+
+      def test_wrap_tracks_colon_form_sgr_codes
+        wrapped = Wrap.new("\e[38:2::255:0:0maaaa bbbb cccc").wrap(9)
+
+        assert_equal("\e[38:2::255:0:0maaaa bbbb\n\e[38:2::255:0:0mcccc", wrapped)
+      end
+
+      def test_wrap_keeps_sgr_replay_bounded
+        input = 8.times.map { |i| "\e[#{31 + (i % 7)}m#{(97 + i).chr * 4}" }.join(' ')
+        wrapped = Wrap.new(input).wrap(5)
+
+        assert_equal([2, 2, 2, 2, 2, 2, 2, 1], wrapped.lines.map { |line| line.scan(/\e\[[\d;:]*m/).length })
+        assert_operator(wrapped.bytesize, :<, input.bytesize * 2)
+      end
+
+      def test_wrap_reconstructs_independent_sgr_attributes
+        wrapped = Wrap.new("\e[1m\e[31maaaa bbbb").wrap(4)
+
+        assert_equal("\e[1m\e[31maaaa\n\e[1;31mbbbb", wrapped)
+      end
+
+      def test_wrap_groups_semicolon_form_extended_colors
+        wrapped = Wrap.new("\e[1m\e[38;2;1;2;3maaaa bbbb").wrap(4)
+
+        assert_equal("\e[1m\e[38;2;1;2;3maaaa\n\e[1;38;2;1;2;3mbbbb", wrapped)
+      end
+
+      def test_wrap_does_not_reinterpret_incomplete_extended_colors
+        wrapped = Wrap.new("\e[38;2;255maaaa bbbb").wrap(4)
+
+        assert_equal("\e[38;2;255maaaa\nbbbb", wrapped)
+      end
+
+      def test_wrap_deduplicates_parameters_in_last_used_order
+        wrapped = Wrap.new("\e[1m\e[22m\e[1maaaa bbbb").wrap(4)
+
+        assert_equal("\e[1m\e[22m\e[1maaaa\n\e[22;1mbbbb", wrapped)
+      end
+
+      def test_wrap_preserves_distinct_unrecognized_parameters
+        wrapped = Wrap.new("\e[76m\e[77maaaa bbbb").wrap(4)
+
+        assert_equal("\e[76m\e[77maaaa\n\e[76;77mbbbb", wrapped)
+      end
+
+      def test_wrap_reopens_a_hyperlink_after_a_break
+        open_link = "\e]8;;https://example.com\e\\"
+        close_link = ANSI::HYPERLINK_END
+        wrapped = Wrap.new("#{open_link}aaaa bbbb cccc#{close_link}").wrap(9)
+
+        assert_equal("#{open_link}aaaa bbbb#{close_link}\n#{open_link}cccc#{close_link}", wrapped)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes some minor layout calculation issues.  This is a big change, for issues that you may never have noticed 😅 

This changes existing width and layout behavior and should ideally ship as part of the pending major 3.0.0 bump (https://github.com/Shopify/cli-ui/pull/622).

Depends on helpers added in #625. 

### Layout stops being wrong around invisible sequences

Anything measured for layout – frame titles, box borders, table columns, centered text – previously counted the bytes of `\e[?25l` (hide cursor), `\e[K` (clear line), and `\e[m` as if they were printed characters. A line containing a hidden-cursor sequence was "10 characters" of phantom width, so borders broke early, padding came up short, and columns misaligned. Those sequences now measure as zero, so frames and tables line up.

### Truncation stops emitting garbage
The old truncater didn't know `?` parameters or OSC sequences, so truncating a line could slice `\e[?25l` in half – printing literal `?25l` fragments – or cut an OSC 8 hyperlink mid-sequence, leaving the terminal with an unterminated escape that can swallow everything after it. Now sequences always pass through whole or not at all, and if the cut lands inside a hyperlink, the link is properly closed before the `….`

Truncated output also always stays one line: a newline measures zero columns, but truncating `"ab\ncd"` to 3 columns gives `ab…`, not `ab\n…` — the cut lands before the line break instead of silently absorbing it.

### Wide glyphs stop overflowing

Emoji render two columns wide but were measured as one, so every emoji in a spin-group title or table cell pushed content one column past the frame border. Width measurement and truncation now agree on two columns, so emoji-bearing lines fit. Same family of fix: 👩‍💻-style ZWJ sequences and accented characters like e+combining-acute are
measured as the single glyph you see, and a string like `🌈🌈🌈` asked to fit in 3 columns actually truncates instead of
sprawling to 6.

The width table covers the real wide-glyph territory, not just the core emoji block: ✅, ⭐, 🚀, 🛒, CJK text (`漢字` is 4 columns), flags, and VS16 emoji-presentation forms like ⚠️ (which is cli-ui's own `Glyph::WARNING`) all measure two columns. `wcwidth(3)` counts VS16 forms as one column, but the terminals cli-ui targets render them as two, so we side with the terminals.

(A vendored wcwidth table remains the exact fix — ambiguous-width East Asian characters are still counted 1 — but this is 🤞 Good Enough for Shopify's use cases 🤞 without new dependencies)

### Wrapped text keeps (and releases) its colors correctly

Two visible fixes in `CLI::UI.puts` word-wrapping:
* Colors that were reset mid-paragraph no longer come back from the dead on the next wrapped line (the reset-detection branch was dead code, so stale colors reaccumulated forever). Resets hiding inside a parameter list count too: `\e[0;33m` and `\e[;1m` kill the codes before them, and only the parameters after the reset are resent on continuation lines
* Truecolor codes in colon form (`\e[38:2::255:0:0m`) now survive onto continuation lines instead of silently dropping to default (and a `0` subparameter there is never mistaken for a reset). Plus a hyperlink spanning a wrap point no longer makes the next line's frame gutter part of the clickable link

### Performance
Performance depends on the input:

 Input| Before| After | Change
----- | ----- | ----- | -----
 Typical ASCII line | 10.4 µs | 0.28 µs | ~37× faster
 44-character CJK line | 19.6 µs | 35 µs | ~1.8× slower
 Emoji-dense text | – | – | ~7× slower

The ASCII fast path makes ordinary text substantially faster. Unicode text requiring grapheme segmentation and width-table lookup is slower in exchange for correct terminal-width measurement.

The absolute cost remains tens of microseconds per line in these benchmarks, but Unicode-heavy output that is measured on every repaint (e.g., Japanese-language spinner) may see a noticeable relative regression.

***Bot-generated explanations follow***

-----

### The grammar

`CSI_SEQUENCE` required at least one parameter character, so `strip_codes` passed `\e[K`, `\e[m`, and private-mode sequences like `\e[?25l` through as text, and `printing_width` counted their bytes as printed columns: `printing_width("\e[?25lx\e[K")` returned `10` for one visible character. It now matches the full CSI grammar (any parameter bytes including private-mode markers, then intermediate bytes, then one final byte). The OSC 8 hyperlink grammar also moves into `ANSI`: `CLI::UI.link` builds links and `Truncater`/`Wrap` close them from the same definitions.

### The walk

`ANSI.each_token` scans a string as alternating runs of whole control sequences and the text between them, so consumers that measure or cut at token boundaries can't slice a *well-formed* sequence open or count its bytes as printable. `printing_width`, `Truncater`, and `Wrap` are all rebuilt on it, replacing three independent hand-rolled parsers (one of which, Truncater's, didn't know about `?` parameters or OSC at all — it sliced `\e[?25l` in half and could emit a dangling unterminated hyperlink).

Input that arrives already mangled is contained rather than compounded: a CSI or OSC sequence missing its terminator at the end of the string (something upstream — a log pipeline, a byte-limited buffer — cut it open) tokenizes as one zero-width sequence, so `Truncater` drops it instead of counting its bytes as columns and slicing it a second time. Mid-string, a missing terminator is ambiguous, so only the trailing case gets this treatment.

### Behavior changes

- `printing_width`: wide glyphs are 2 columns — the East Asian Wide and Fullwidth blocks, the emoji planes, scattered BMP emoji (✅, ⭐, ❌), and VS16 emoji-presentation clusters like ⚠️ (was 1 for all of these; Truncater said 2 for the core emoji block only — they now agree via the shared terminal-width helper and its generated Unicode table). Newlines and combining marks are 0 columns (was 1), and ZWJ sequences are measured as single grapheme clusters. **Table columns, frame padding, and spin_group truncation all shift for emoji- and CJK-containing content; downstream repos with exact-output assertions will churn.** `Glyph::WARNING` (⚠️) itself goes from 1 column to 2.
- `Truncater.call`: no longer slices private-mode sequences mid-way or counts their bodies as text; closes an open OSC 8 hyperlink at the cut; measures by columns even on the fast path (`call("🌈🌈🌈", 3)` previously returned all six columns untouched because the early-out compared character count); counts a line break as one column so truncated output stays one line (`call("ab\ncd", 3)` → `ab…`); drops a trailing unterminated sequence past the cut instead of re-slicing it.
- `Wrap`: an `\e[0m` reset now actually clears the SGR codes resent after each break — the old reset branch was the single-quoted literal `'\x1B[0?m'`, which no token ever equals, so codes accumulated forever and a reset color could come back on the next wrapped line. A reset hiding mid-list (`\e[0;33m`, `\e[;1m`) is detected by parsing the parameter list, and only the parameters after the last reset survive to continuation lines. Colon-form extended colors (`\e[38:2::255:0:0m`) are now tracked too — a `0` subparameter never counts as a reset — and a hyperlink spanning a break is closed and reopened so the frame gutter stays outside the link.
- Removed public constants: `Truncater::EMOJI_RANGE` and `Truncater::PARSE_ROOT`/`PARSE_ANSI`/`PARSE_ESC`/`PARSE_ZWJ` (internals of the deleted hand-rolled parser). A GitHub-wide code search finds no references outside cli-ui and wholesale vendored copies of the gem, so no deprecation aliases are provided. `Truncater::TRUNCATED` remains. New public surface: `ANSI.each_token`, `ANSI.grapheme_width`, `ANSI::CSI_SEQUENCE`/`OSC_SEQUENCE`/`SEQUENCE`/`UNTERMINATED_SEQUENCE`/`TEXT_RUN`/`HYPERLINK`/`HYPERLINK_END`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

