### PR TITLE
Make the router's routing state authoritative instead of sniffed

### DIFF
--- a/lib/cli/ui/stdout_router.rb
+++ b/lib/cli/ui/stdout_router.rb
@@ -11,11 +11,42 @@ require_relative '../../../vendor/reentrant_mutex'
 module CLI
   module UI
     module StdoutRouter
+      WRITE_WITHOUT_CLI_UI = :write_without_cli_ui
+      COMPATIBILITY_WRITE_IVAR = :@__cli_ui_stdout_router_compatibility_write
+      private_constant :COMPATIBILITY_WRITE_IVAR
+
+      # Defined here rather than on the singleton class, where callers had no
+      # way to name it.
+      NotEnabled = Class.new(StandardError)
+
+      class CompatibilityWrite
+        #: Method
+        attr_reader :installed_method
+
+        #: Method
+        attr_reader :original_write
+
+        #: (Method installed_method, Method original_write) -> void
+        def initialize(installed_method, original_write)
+          @installed_method = installed_method
+          @original_write = original_write
+        end
+      end
+      private_constant :CompatibilityWrite
+
       class Writer
-        #: (io_like stream, Symbol name) -> void
-        def initialize(stream, name)
+        #: Method
+        attr_reader :original_write
+
+        # `original_write` must be the stream's pre-routing `write`; it is
+        # required because resolving it from an already-routed stream would
+        # stack a second Writer on the first. Holding the method itself keeps
+        # an in-flight write working after `deactivate`.
+        #: (io_like stream, Symbol name, Method original_write) -> void
+        def initialize(stream, name, original_write)
           @stream = stream
           @name = name
+          @original_write = original_write
         end
 
         #: (*Object args) -> Integer
@@ -38,7 +69,7 @@ module CLI
           end
 
           stream_args = prepend_id(@stream, strs) #: as untyped
-          ret = @stream.write_without_cli_ui(*stream_args) #: as Integer
+          ret = @original_write.call(*stream_args) #: as Integer
           if (dup = StdoutRouter.duplicate_output_to)
             begin
               dup_args = prepend_id(dup, strs) #: as untyped
@@ -207,38 +238,39 @@ module CLI
         def run
           require 'stringio'
 
-          StdoutRouter.assert_enabled!
+          StdoutRouter.with_enabled do
+            prev_frame_inset = Thread.current[:no_cliui_frame_inset]
+            prev_hook = Thread.current[:cliui_output_hook]
+            Thread.current[:cliui_current_capture] = self
 
-          Thread.current[:cliui_current_capture] = self
-
-          prev_frame_inset = Thread.current[:no_cliui_frame_inset]
-          prev_hook = Thread.current[:cliui_output_hook]
-
-          if Thread.current.respond_to?(:report_on_exception)
-            Thread.current.report_on_exception = false
-          end
-
-          self.class.with_stdin_masked do
-            Thread.current[:no_cliui_frame_inset] = !@with_frame_inset
-            Thread.current[:cliui_output_hook] = ->(data, stream) do
-              stream = :stdout if @merged_output
-              case stream
-              when :stdout
-                @out.write(data)
-                @duplicate_output_to.write(data)
-              when :stderr
-                @err.write(data)
-              else raise
+            begin
+              if Thread.current.respond_to?(:report_on_exception)
+                Thread.current.report_on_exception = false
               end
-              print_captured_output # suppress writing to terminal by default
-            end
 
-            @block.call
+              self.class.with_stdin_masked do
+                Thread.current[:no_cliui_frame_inset] = !@with_frame_inset
+                Thread.current[:cliui_output_hook] = ->(data, stream) do
+                  stream = :stdout if @merged_output
+                  case stream
+                  when :stdout
+                    @out.write(data)
+                    @duplicate_output_to.write(data)
+                  when :stderr
+                    @err.write(data)
+                  else raise
+                  end
+                  print_captured_output # suppress writing to terminal by default
+                end
+
+                @block.call
+              end
+            ensure
+              Thread.current[:cliui_output_hook] = prev_hook
+              Thread.current[:no_cliui_frame_inset] = prev_frame_inset
+              Thread.current[:cliui_current_capture] = nil
+            end
           end
-        ensure
-          Thread.current[:cliui_output_hook] = prev_hook
-          Thread.current[:no_cliui_frame_inset] = prev_frame_inset
-          Thread.current[:cliui_current_capture] = nil
         end
 
         #: -> String
@@ -307,10 +339,6 @@ module CLI
       end
 
       class << self
-        WRITE_WITHOUT_CLI_UI = :write_without_cli_ui
-
-        NotEnabled = Class.new(StandardError)
-
         #: io_like?
         attr_accessor :duplicate_output_to
 
@@ -336,65 +364,176 @@ module CLI
 
         #: -> void
         def assert_enabled!
-          raise NotEnabled unless enabled?
+          raise NotEnabled unless current_streams.all? { |stream,| routed?(stream) }
         end
 
+        # Routes only streams not already routed by this module, then unroutes
+        # only those streams when the scope exits.
         #: [T] { -> T } -> T
         def with_enabled(&block)
-          enable
+          activated = activate_current_streams
           yield
         ensure
-          disable
+          activated&.reverse_each { |stream| deactivate(stream) }
         end
 
         # TODO: remove this
         #: -> void
         def ensure_activated
-          enable unless enabled?
+          enable
         end
 
+        # Routes the current $stdout/$stderr; returns whether anything changed.
+        # Additive and per-stream so a half-routed process can recover without
+        # unrouting a stream that was only replaced in the globals temporarily.
         #: -> bool
         def enable
-          return false if enabled?($stdout) || enabled?($stderr)
-
-          activate($stdout, :stdout)
-          activate($stderr, :stderr)
-          true
+          !activate_current_streams.empty?
         end
 
         #: (?io_like stream) -> bool
-        def enabled?(stream = $stdout)
-          stream.respond_to?(WRITE_WITHOUT_CLI_UI)
+        def routed?(stream = $stdout)
+          !route_writers[stream].nil?
         end
 
-        #: -> bool
-        def disable
-          return false unless enabled?($stdout) && enabled?($stderr)
+        # Kept for compatibility. `routed?` names the membership check more
+        # precisely.
+        #: (?io_like stream) -> bool
+        def enabled?(stream = $stdout)
+          routed?(stream)
+        end
 
-          deactivate($stdout)
-          deactivate($stderr)
-          true
+        # Returns a snapshot so callers can inspect routing without gaining
+        # access to the mutable registry or its Writer values.
+        #: -> Array[io_like]
+        def routed_streams
+          streams = [] #: Array[io_like]
+          route_writers.each_key do |stream|
+            streams << stream if routed?(stream)
+          end
+          streams
+        end
+
+        # Unroutes `stream`, or every routed stream when none is given; returns
+        # whether anything changed.
+        #: (?io_like? stream) -> bool
+        def disable(stream = nil)
+          routed = stream.nil? ? routed_streams : [stream].select { |candidate| routed?(candidate) }
+          routed.each { |routed_stream| deactivate(routed_stream) }
+          !routed.empty?
+        end
+
+        # Writes past the router: no frame inset, capture hooks, or output
+        # duplication. Prefer this to calling WRITE_WITHOUT_CLI_UI directly,
+        # which exists only after a stream has been routed at least once.
+        #: (io_like stream, *Object args) -> Integer
+        def write_without_routing(stream, *args)
+          compatibility_write = owned_compatibility_write(stream)
+          original_write = compatibility_write&.original_write || route_writers[stream]&.original_write
+          write_args = args #: as untyped
+          return stream.write(*write_args) unless original_write
+
+          original_write.call(*write_args) #: as Integer
         end
 
         private
 
+        # Weak keys let a caller-owned stream and its routing wrapper disappear
+        # together if the caller drops the stream without explicitly disabling
+        # it. Ruby 3.2's WeakMap has no `delete`, so deactivation tombstones the
+        # value; public readers filter those entries.
+        #: -> untyped
+        def route_writers
+          @route_writers ||= ObjectSpace::WeakMap.new
+        end
+
+        #: -> Hash[io_like, Symbol]
+        def current_streams
+          streams = {}.compare_by_identity #: Hash[io_like, Symbol]
+          streams[$stdout] = :stdout
+          streams[$stderr] = :stderr unless streams.key?($stderr)
+          streams
+        end
+
+        #: (Hash[io_like, Symbol] streams) -> Array[io_like]
+        def activate_streams(streams)
+          streams_to_activate = streams.reject { |stream,| routed?(stream) }
+          return [] unless streams_to_activate.all? { |stream,| compatibility_write_available?(stream) }
+
+          activated = [] #: Array[io_like]
+          begin
+            streams_to_activate.each do |stream, streamname|
+              activate(stream, streamname)
+              activated << stream
+            end
+            activated
+          rescue
+            activated.reverse_each { |stream| deactivate(stream) }
+            raise
+          end
+        end
+
+        #: -> Array[io_like]
+        def activate_current_streams
+          activate_streams(current_streams)
+        end
+
+        #: (io_like stream) -> bool
+        def compatibility_write_available?(stream)
+          !stream.respond_to?(WRITE_WITHOUT_CLI_UI, true) || !owned_compatibility_write(stream).nil?
+        end
+
         #: (io_like stream) -> void
         def deactivate(stream)
+          original_write = route_writers[stream]&.original_write
+          return unless original_write
+
           sc = stream.singleton_class
+
           sc.send(:remove_method, :write)
-          sc.send(:alias_method, :write, WRITE_WITHOUT_CLI_UI)
+          # Restore only a `write` we displaced; a stream that inherited its
+          # `write` gets the class method back.
+          sc.send(:define_method, :write, original_write) if original_write&.owner == sc
+          route_writers[stream] = nil
         end
 
         #: (io_like stream, Symbol streamname) -> void
         def activate(stream, streamname)
-          writer = StdoutRouter::Writer.new(stream, streamname)
+          original_write = stream.method(:write)
+          writer = StdoutRouter::Writer.new(stream, streamname, original_write)
 
-          raise if stream.respond_to?(WRITE_WITHOUT_CLI_UI)
-
-          stream.singleton_class.send(:alias_method, WRITE_WITHOUT_CLI_UI, :write)
+          install_compatibility_write(stream, original_write)
           stream.define_singleton_method(:write) do |*args|
             writer.write(*args)
           end
+          route_writers[stream] = writer
+        end
+
+        # The supported bypass is `write_without_routing`; this is the same
+        # thing under the name out-of-tree callers already reach for. Closing
+        # over the pre-routing method keeps it a bypass after disable, even if
+        # a later `write` wrapper calls the compatibility method itself.
+        #: (io_like stream, Method original_write) -> void
+        def install_compatibility_write(stream, original_write)
+          return if owned_compatibility_write(stream)
+
+          stream.singleton_class.send(:define_method, WRITE_WITHOUT_CLI_UI) do |*args|
+            write_args = args #: as untyped
+            original_write.call(*write_args)
+          end
+          installed_method = stream.method(WRITE_WITHOUT_CLI_UI)
+          compatibility_write = CompatibilityWrite.new(installed_method, original_write)
+          stream.instance_variable_set(COMPATIBILITY_WRITE_IVAR, compatibility_write)
+        end
+
+        #: (io_like stream) -> CompatibilityWrite?
+        def owned_compatibility_write(stream)
+          compatibility_write = stream.instance_variable_get(COMPATIBILITY_WRITE_IVAR)
+          return unless compatibility_write.is_a?(CompatibilityWrite)
+          return unless stream.respond_to?(WRITE_WITHOUT_CLI_UI, true)
+          return unless stream.method(WRITE_WITHOUT_CLI_UI) == compatibility_write.installed_method
+
+          compatibility_write
         end
       end
     end

--- a/test/cli/ui/printer_test.rb
+++ b/test/cli/ui/printer_test.rb
@@ -6,8 +6,7 @@ module CLI
   module UI
     class PrinterTest < Minitest::Test
       def test_puts_color
-        out, _ = capture_io do
-          CLI::UI::StdoutRouter.ensure_activated
+        out, _ = capture_io_with_router do
           assert(Printer.puts('foo', frame_color: :red))
         end
 
@@ -20,8 +19,7 @@ module CLI
         out = nil
         capture_io do
           Frame.open('test') do
-            out, _ = capture_io do
-              CLI::UI::StdoutRouter.ensure_activated
+            out, _ = capture_io_with_router do
               Printer.puts('foo', frame_color: :red)
             end
           end
@@ -37,8 +35,7 @@ module CLI
         out = nil
         capture_io do
           Frame.open(overlong_preamble, success_text: overlong_suffix) do
-            out, _ = capture_io do
-              CLI::UI::StdoutRouter.ensure_activated
+            out, _ = capture_io_with_router do
               Printer.puts('foo', frame_color: :red)
             end
           end

--- a/test/cli/ui/progress_test.rb
+++ b/test/cli/ui/progress_test.rb
@@ -33,8 +33,7 @@ module CLI
       end
 
       def test_updating_title
-        out, err = capture_io do
-          CLI::UI::StdoutRouter.ensure_activated
+        out, err = capture_io_with_router do
           Progress.progress do |bar|
             3.times do |i|
               bar.update_title("Title #{i}")

--- a/test/cli/ui/spinner/spin_group_test.rb
+++ b/test/cli/ui/spinner/spin_group_test.rb
@@ -7,9 +7,7 @@ module CLI
     module Spinner
       class SpinGroupTest < Minitest::Test
         def test_spin_group
-          _out, err = capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
-
+          _out, err = capture_io_with_router do
             sg = SpinGroup.new
             sg.add('s') do
               true
@@ -22,9 +20,7 @@ module CLI
         end
 
         def test_spin_group_auto_debrief_false
-          _out, err = capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
-
+          _out, err = capture_io_with_router do
             sg = SpinGroup.new(auto_debrief: false)
             sg.add('s') do
               true
@@ -37,9 +33,7 @@ module CLI
         end
 
         def test_spin_group_success_debrief
-          capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
-
+          capture_io_with_router do
             debriefer = ->(title, out, err) {}
             sg = SpinGroup.new
             sg.success_debrief(&debriefer)
@@ -54,8 +48,7 @@ module CLI
         end
 
         def test_spin_group_with_custom_work_queue
-          capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
+          capture_io_with_router do
             work_queue = CLI::UI::WorkQueue.new(2)
             sg = SpinGroup.new(work_queue: work_queue)
 
@@ -88,8 +81,7 @@ module CLI
         end
 
         def test_spin_group_with_max_concurrent
-          capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
+          capture_io_with_router do
             sg = SpinGroup.new(max_concurrent: 2)
 
             startup_queue = Queue.new
@@ -124,8 +116,7 @@ module CLI
         end
 
         def test_spin_group_interrupt
-          capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
+          capture_io_with_router do
             sg = SpinGroup.new
             task_completed = false
             task_interrupted = false
@@ -158,8 +149,7 @@ module CLI
         end
 
         def test_spin_group_stop
-          capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
+          capture_io_with_router do
             sg = SpinGroup.new
 
             task_started = false
@@ -188,8 +178,7 @@ module CLI
         end
 
         def test_spin_group_nested_stop
-          capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
+          capture_io_with_router do
             sg = SpinGroup.new
 
             sg.add('Outer task') do
@@ -203,8 +192,7 @@ module CLI
         end
 
         def test_spin_group_interrupt_with_debrief
-          capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
+          capture_io_with_router do
             sg = SpinGroup.new(interrupt_debrief: true)
             task_interrupted = false
             debrief_called = false
@@ -245,8 +233,7 @@ module CLI
         end
 
         def test_spin_group_interrupt_without_debrief
-          capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
+          capture_io_with_router do
             sg = SpinGroup.new(interrupt_debrief: false)
 
             # Use Queue for thread-safe signaling
@@ -282,8 +269,7 @@ module CLI
         end
 
         def test_task_on_done_callback
-          capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
+          capture_io_with_router do
             sg = SpinGroup.new
 
             callback_executed = false

--- a/test/cli/ui/spinner_test.rb
+++ b/test/cli/ui/spinner_test.rb
@@ -6,8 +6,7 @@ module CLI
   module UI
     class SpinnerTest < Minitest::Test
       def test_spinner
-        out, err = capture_io do
-          CLI::UI::StdoutRouter.ensure_activated
+        out, err = capture_io_with_router do
           CLI::UI::Spinner.spin('sleeping') do
           end
         end
@@ -17,8 +16,7 @@ module CLI
       end
 
       def test_async
-        out, err = capture_io do
-          CLI::UI::StdoutRouter.ensure_activated
+        out, err = capture_io_with_router do
           spinner = CLI::UI::Spinner::Async.start('sleeping')
           sleep(CLI::UI::Spinner::PERIOD * 2.5)
           spinner.stop
@@ -29,8 +27,7 @@ module CLI
       end
 
       def test_updating_title
-        out, err = capture_io do
-          CLI::UI::StdoutRouter.ensure_activated
+        out, err = capture_io_with_router do
           CLI::UI::Spinner.spin('私') do |task|
             assert(task)
             assert_respond_to(task, :update_title)
@@ -50,8 +47,7 @@ module CLI
 
       def test_spinner_without_emojis
         with_os_mock_test do
-          out, err = capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
+          out, err = capture_io_with_router do
             spinner = CLI::UI::Spinner::Async.start('sleeping')
             sleep(CLI::UI::Spinner::PERIOD * 2.5)
             spinner.stop
@@ -66,8 +62,7 @@ module CLI
 
       def test_updating_title_without_emojis
         with_os_mock_test do
-          out, err = capture_io do
-            CLI::UI::StdoutRouter.ensure_activated
+          out, err = capture_io_with_router do
             CLI::UI::Spinner.spin('私') do |task|
               assert(task)
               assert_respond_to(task, :update_title)
@@ -89,8 +84,7 @@ module CLI
       end
 
       def test_spinner_task_error_through_raising_exception
-        out, err = capture_io do
-          CLI::UI::StdoutRouter.ensure_activated
+        out, err = capture_io_with_router do
           CLI::UI::Spinner.spin('broken') do
             sleep(CLI::UI::Spinner::PERIOD * 0.5)
             $stderr.puts 'not empty'
@@ -106,8 +100,7 @@ module CLI
       end
 
       def test_spinner_task_error_through_returning_error
-        out, _ = capture_io do
-          CLI::UI::StdoutRouter.ensure_activated
+        out, _ = capture_io_with_router do
           CLI::UI::Spinner.spin('broken') do
             $stderr.puts 'not empty'
             sleep(CLI::UI::Spinner::PERIOD * 0.5)

--- a/test/cli/ui/stdout_router_test.rb
+++ b/test/cli/ui/stdout_router_test.rb
@@ -24,6 +24,446 @@ module CLI
         end
       end
 
+      def test_write_without_cli_ui_constant_is_accessible
+        assert_equal(:write_without_cli_ui, StdoutRouter::WRITE_WITHOUT_CLI_UI)
+      end
+
+      def test_writer_requires_the_original_write
+        assert_raises(ArgumentError) do
+          StdoutRouter::Writer.new(StringIO.new, :stdout)
+        end
+      end
+
+      def test_router_can_reenable_after_disable
+        capture_io do
+          assert(StdoutRouter.enable)
+          assert($stdout.respond_to?(:write_without_cli_ui))
+          assert(StdoutRouter.disable)
+
+          refute_predicate(StdoutRouter, :routed?)
+          assert($stdout.respond_to?(:write_without_cli_ui))
+          $stdout.write_without_cli_ui('bypassed')
+          assert_equal('bypassed', $stdout.string)
+
+          GC.start
+          assert(StdoutRouter.enable)
+          assert_predicate(StdoutRouter, :routed?)
+
+          cap = StdoutRouter::Capture.new { print('hi') }
+          cap.run
+          assert_equal('hi', cap.stdout)
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_capture_routes_its_current_streams
+        capture_io do
+          cap = StdoutRouter::Capture.new do
+            $stdout.write('out')
+            $stderr.write('err')
+          end
+          cap.run
+
+          assert_equal('out', cap.stdout)
+          assert_equal('err', cap.stderr)
+          refute(StdoutRouter.routed?($stdout))
+          refute(StdoutRouter.routed?($stderr))
+        end
+      end
+
+      def test_capture_temporarily_routes_a_replaced_stderr
+        capture_io do
+          StdoutRouter.enable
+          original_stderr = $stderr
+          $stderr = StringIO.new
+
+          cap = StdoutRouter::Capture.new do
+            $stdout.write('out')
+            $stderr.write('err')
+          end
+          cap.run
+
+          assert_equal('out', cap.stdout)
+          assert_equal('err', cap.stderr)
+          assert(StdoutRouter.routed?($stdout))
+          assert(StdoutRouter.routed?(original_stderr))
+          refute(StdoutRouter.routed?($stderr))
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_assert_enabled_requires_both_current_streams_to_be_routed
+        capture_io do
+          assert_raises(StdoutRouter::NotEnabled) { StdoutRouter.assert_enabled! }
+
+          StdoutRouter.enable
+          StdoutRouter.assert_enabled!
+          StdoutRouter.disable($stderr)
+          assert_raises(StdoutRouter::NotEnabled) { StdoutRouter.assert_enabled! }
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_disable_leaves_only_the_compatibility_alias
+        capture_io do
+          StdoutRouter.enable
+          StdoutRouter.disable
+
+          assert_equal([:write_without_cli_ui], $stdout.singleton_methods)
+          assert_equal([:write_without_cli_ui], $stderr.singleton_methods)
+        end
+      end
+
+      def test_disable_restores_a_pre_existing_singleton_write
+        capture_io do
+          written = []
+          $stdout.define_singleton_method(:write) do |*args|
+            written << args.join
+            super(*args)
+          end
+
+          StdoutRouter.enable
+          $stdout.write('routed')
+          StdoutRouter.disable
+          $stdout.write('plain')
+
+          assert_equal(['routed', 'plain'], written)
+          assert_equal([:write, :write_without_cli_ui], $stdout.singleton_methods.sort)
+        end
+      end
+
+      def test_enable_routes_a_stream_that_replaced_a_routed_one
+        capture_io do
+          StdoutRouter.enable
+          original_stderr = $stderr
+          $stderr = StringIO.new
+
+          assert(StdoutRouter.enable)
+          assert(StdoutRouter.routed?($stderr))
+          assert(StdoutRouter.routed?(original_stderr))
+
+          assert(StdoutRouter.disable(original_stderr))
+          refute(StdoutRouter.routed?(original_stderr))
+          refute(StdoutRouter.disable(original_stderr))
+
+          assert(StdoutRouter.disable)
+          refute_predicate(StdoutRouter, :routed?)
+          refute(StdoutRouter.routed?($stderr))
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_disable_unroutes_streams_replaced_in_globals
+        capture_io do
+          StdoutRouter.enable
+          original_stdout = $stdout
+          $stdout = StringIO.new
+
+          assert(StdoutRouter.disable)
+          refute(StdoutRouter.routed?(original_stdout))
+          assert(original_stdout.respond_to?(:write_without_cli_ui))
+          refute(StdoutRouter.routed?($stdout))
+          assert_empty(StdoutRouter.routed_streams)
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_enable_leaves_a_transiently_swapped_stream_routed
+        capture_io do
+          StdoutRouter.enable
+          real_stdout = $stdout
+
+          $stdout = StringIO.new
+          StdoutRouter.ensure_activated
+          $stdout = real_stdout
+
+          assert(StdoutRouter.routed?(real_stdout))
+          cap = StdoutRouter::Capture.new { print('still routed') }
+          cap.run
+          assert_equal('still routed', cap.stdout)
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_scoped_routing_does_not_retain_previous_capture_streams
+        previous_streams = nil
+        capture_io_with_router do
+          previous_streams = [$stdout, $stderr]
+        end
+
+        previous_streams.each { |stream| refute(StdoutRouter.routed?(stream)) }
+        assert_empty(StdoutRouter.routed_streams)
+
+        capture_io_with_router do
+          previous_streams.each { |stream| refute(StdoutRouter.routed?(stream)) }
+          assert_equal(2, StdoutRouter.routed_streams.size)
+        end
+        assert_empty(StdoutRouter.routed_streams)
+      end
+
+      def test_registry_does_not_retain_abandoned_routed_streams
+        script = <<~RUBY
+          require 'stringio'
+          require 'cli/ui'
+
+          def route_transient_streams
+            original_stdout = $stdout
+            original_stderr = $stderr
+            $stdout = StringIO.new
+            $stderr = StringIO.new
+            CLI::UI::StdoutRouter.enable
+          ensure
+            $stdout = original_stdout
+            $stderr = original_stderr
+          end
+
+          5.times { route_transient_streams }
+          10.times { GC.start }
+          abort("retained \#{CLI::UI::StdoutRouter.routed_streams.size} streams") unless
+            CLI::UI::StdoutRouter.routed_streams.empty?
+        RUBY
+
+        lib = File.expand_path('../../../lib', __dir__)
+        stdout, stderr, status = Open3.capture3(RbConfig.ruby, '-I', lib, '-e', script)
+
+        assert(status.success?, "stdout:\n#{stdout}\nstderr:\n#{stderr}")
+      end
+
+      def test_routed_streams_returns_a_snapshot
+        capture_io do
+          StdoutRouter.enable
+          streams = StdoutRouter.routed_streams
+          streams.clear
+
+          assert_equal(2, StdoutRouter.routed_streams.size)
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_enabled_remains_an_alias_for_routed_membership
+        capture_io do
+          refute_predicate(StdoutRouter, :routed?)
+          refute_predicate(StdoutRouter, :enabled?)
+          StdoutRouter.enable
+          assert_predicate(StdoutRouter, :routed?)
+          assert_predicate(StdoutRouter, :enabled?)
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_compatibility_bypass_does_not_reenter_a_later_write_wrapper
+        capture_io do
+          StdoutRouter.enable
+          StdoutRouter.disable
+
+          calls = 0
+          $stdout.define_singleton_method(:write) do |*args|
+            calls += 1
+            $stdout.write_without_cli_ui(*args)
+          end
+
+          $stdout.write('unrouted')
+          StdoutRouter.enable
+          $stdout.write('routed')
+
+          assert_equal(2, calls)
+          assert_equal('unroutedrouted', $stdout.string)
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_public_bypass_does_not_reenter_a_later_write_wrapper
+        capture_io do
+          StdoutRouter.enable
+          StdoutRouter.disable
+
+          calls = 0
+          stream = $stdout
+          stream.define_singleton_method(:write) do |*args|
+            calls += 1
+            StdoutRouter.write_without_routing(stream, *args)
+          end
+
+          stream.write('unrouted')
+          StdoutRouter.enable
+          stream.write('routed')
+
+          assert_equal(2, calls)
+          assert_equal('unroutedrouted', stream.string)
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_enable_handles_stderr_aliased_to_stdout
+        capture_io do
+          $stderr = $stdout
+
+          assert(StdoutRouter.enable)
+          assert(StdoutRouter.disable)
+          assert_equal([:write_without_cli_ui], $stdout.singleton_methods)
+        end
+      end
+
+      def test_enable_declines_a_stream_owned_by_another_router
+        capture_io do
+          original_write = $stderr.method(:write)
+          previous_hook = Thread.current[:cliui_output_hook]
+          hook_calls = 0
+          $stderr.singleton_class.send(:define_method, :write_without_cli_ui, original_write)
+          $stderr.define_singleton_method(:write) do |*args|
+            Thread.current[:cliui_output_hook]&.call(args.join, :stderr)
+            original_write.call(*args)
+          end
+          Thread.current[:cliui_output_hook] = ->(*) { hook_calls += 1 }
+
+          refute(StdoutRouter.enable)
+          refute(StdoutRouter.routed?($stdout))
+          refute(StdoutRouter.routed?($stderr))
+
+          $stderr.write('once')
+          assert_equal(1, hook_calls)
+          assert_equal('once', $stderr.string)
+          refute(StdoutRouter.disable)
+        ensure
+          Thread.current[:cliui_output_hook] = previous_hook
+          StdoutRouter.disable
+        end
+      end
+
+      def test_enable_declines_a_foreign_marker_before_routing_any_stream
+        capture_io do
+          $stderr.singleton_class.send(:alias_method, :write_without_cli_ui, :write)
+
+          refute(StdoutRouter.enable)
+          assert_empty(StdoutRouter.routed_streams)
+          assert($stderr.respond_to?(:write_without_cli_ui))
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_enable_unroutes_only_streams_activated_before_a_failure
+        capture_io do
+          failing_stderr = StringIO.new
+          failing_stderr.define_singleton_method(:define_singleton_method) do |name, *, &|
+            raise "unexpected method: #{name}" unless name == :write
+
+            raise 'cannot install write'
+          end
+          $stderr = failing_stderr
+
+          error = assert_raises(RuntimeError) do
+            StdoutRouter.enable
+          end
+          assert_equal('cannot install write', error.message)
+          refute(StdoutRouter.routed?($stdout))
+          refute(StdoutRouter.routed?($stderr))
+          assert_empty(StdoutRouter.routed_streams)
+
+          $stdout.write_without_cli_ui('unrouted')
+          $stderr.write_without_cli_ui('also unrouted')
+          assert_equal('unrouted', $stdout.string)
+          assert_equal('also unrouted', $stderr.string)
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_failed_enable_preserves_existing_routes
+        capture_io do
+          StdoutRouter.enable
+          original_stderr = $stderr
+          failing_stderr = StringIO.new
+          failing_stderr.define_singleton_method(:define_singleton_method) do |name, *, &|
+            raise "unexpected method: #{name}" unless name == :write
+
+            raise 'cannot install write'
+          end
+          $stderr = failing_stderr
+
+          error = assert_raises(RuntimeError) { StdoutRouter.enable }
+          assert_equal('cannot install write', error.message)
+          assert(StdoutRouter.routed?($stdout))
+          assert(StdoutRouter.routed?(original_stderr))
+          refute(StdoutRouter.routed?(failing_stderr))
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_in_flight_writes_survive_disable
+        capture_io do
+          StdoutRouter.enable
+          in_flight = $stdout.method(:write)
+          StdoutRouter.disable
+
+          in_flight.call('late')
+          assert_includes($stdout.string, 'late')
+        end
+      end
+
+      def test_write_without_routing_bypasses_the_router
+        capture_io do
+          StdoutRouter.enable
+          cap = StdoutRouter::Capture.new { StdoutRouter.write_without_routing($stdout, 'bypass') }
+          cap.run
+
+          assert_equal('', cap.stdout)
+          assert_includes($stdout.string, 'bypass')
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_write_without_routing_falls_back_to_write_when_disabled
+        capture_io do
+          StdoutRouter.write_without_routing($stdout, 'unrouted')
+
+          assert_includes($stdout.string, 'unrouted')
+        end
+      end
+
+      def test_with_enabled_preserves_already_enabled_router
+        capture_io do
+          StdoutRouter.enable
+          StdoutRouter.with_enabled {}
+
+          assert_predicate(StdoutRouter, :routed?)
+          cap = StdoutRouter::Capture.new { print('still routed') }
+          cap.run
+          assert_equal('still routed', cap.stdout)
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
+      def test_with_enabled_unroutes_only_what_it_routed
+        capture_io do
+          StdoutRouter.enable
+          StdoutRouter.disable($stderr)
+
+          StdoutRouter.with_enabled do
+            assert(StdoutRouter.routed?($stdout))
+            assert(StdoutRouter.routed?($stderr))
+          end
+
+          assert(StdoutRouter.routed?($stdout))
+          refute(StdoutRouter.routed?($stderr))
+        ensure
+          StdoutRouter.disable
+        end
+      end
+
       def test_frame_can_autoload_after_router_is_enabled
         script = <<~RUBY
           require 'stringio'
@@ -41,7 +481,7 @@ module CLI
 
             CLI::UI::Frame.open('Repro') { puts 'body' }
           ensure
-            if defined?(CLI::UI::StdoutRouter) && CLI::UI::StdoutRouter.enabled?($stdout)
+            if defined?(CLI::UI::StdoutRouter) && CLI::UI::StdoutRouter.routed?($stdout)
               CLI::UI::StdoutRouter.disable
             end
             $stdout = original_stdout

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,3 +69,9 @@ end
 
 require 'minitest/autorun'
 require 'mocha/minitest'
+
+def capture_io_with_router(&block)
+  capture_io do
+    CLI::UI::StdoutRouter.with_enabled(&block)
+  end
+end


### PR DESCRIPTION
## Bug

`StdoutRouter.disable` restored the original `write` method but left the `write_without_cli_ui` compatibility method installed. Because `enabled?` inferred routing from that method, the process could reach a contradictory state:

- routing was inactive,
- `enabled?` still returned `true`,
- `enable` refused to route the stream again,
- `Capture#run` accepted the false-positive state and silently captured nothing.

Resolving enable/disable only through the current `$stdout` and `$stderr` also orphaned routes when either global was replaced. `with_enabled` compounded the problem by unconditionally disabling on exit, including routes that existed before entering its scope.

## Fix

Routing state now lives in a weak identity registry rather than being inferred from methods installed on a stream.

- **Routing membership is explicit.** `routed?(stream)` checks the registry, `enabled?` remains as a compatibility alias, and `routed_streams` returns a read-only snapshot for inspection.
- **`enable` is additive and per-stream.** It routes the current `$stdout` and `$stderr` without discarding routes temporarily displaced from those globals. `disable(stream)` removes one route; no-argument `disable` drains every live registered route.
- **Scoped activation unwinds only its own work.** `with_enabled` remembers only streams it newly routed and removes only those on exit. If a later stream fails to activate, activation rolls back only streams added by that attempt and preserves pre-existing routes.
- **`Capture` establishes the routing it needs.** `Capture#run` executes inside `with_enabled`, so disabled, half-routed, or partially replaced stdout/stderr globals are routed for the capture and restored afterward instead of raising or letting output escape.
- **The registry does not retain abandoned caller-owned streams.** Active routes are held in an `ObjectSpace::WeakMap`; callers should still pair explicit enable/disable operations, but dropping a transient stream no longer pins it for the process lifetime.
- **The compatibility bypass remains a real bypass.** The router-installed `write_without_cli_ui` closes over the stream's pre-routing `write`. `write_without_routing` uses the same method when available, so a later `write` wrapper can call either bypass without re-entering itself.
- **Independent cli-ui copies do not stack routers.** A stream-owned ownership record distinguishes this router's permanent compatibility method from a foreign one. Activation preflights all current streams and benignly declines before changing anything if another copy already owns one.
- **`Writer` requires the pre-routing method explicitly.** This prevents accidentally constructing a Writer around an already-routed `write`, preserves pre-existing singleton wrappers during normal disable, and lets in-flight writes finish after deactivation.
- **Temporary test streams use scoped routing.** Tests that replace stdio with `capture_io` use `with_enabled`, avoiding accidental long-lived routes.

The earlier role-retagging and exact routing-state restoration layer was removed. Routing is additive and idempotent; scopes need only remember the streams they added, not rewrite the roles or wrappers of existing routes.

## Tests

Coverage includes:

- enable → disable → GC → re-enable,
- transient and permanent `$stdout`/`$stderr` replacement,
- aliased stdout/stderr,
- targeted and global disable,
- nested/scoped activation and failure rollback,
- capture while disabled or partially routed,
- compatibility and public bypasses called by later `write` wrappers,
- foreign compatibility markers and duplicate-router hook prevention,
- weak-registry collection of abandoned streams,
- public routing inspection without mutable registry access,
- pre-existing singleton `write` restoration,
- in-flight writes and direct bypass behavior.

Validation:

- 156 tests and 509 assertions across seeds `630`, `20260817`, and `8675309`, with one existing skip,
- RuboCop clean,
- Sorbet clean.

🤖 Generated with LLM assistance

(posted by an LLM bot on behalf of Gord)
